### PR TITLE
Load settings from server.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,6 @@ buck-out/
 #
 # Pods/
 
-src/AppConfig.json
 /android/app/google-services.json
 
 # Bundle artifact

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ matrix:
     env: LANE='node'
     node_js: 8
     cache: yarn
-    before_script:
-      - cp src/AppConfig.json.dist src/AppConfig.json
   - language: android
     env: LANE='android'
     sudo: required
@@ -30,7 +28,6 @@ matrix:
     before_script:
       - npm install -g yarn
       - yarn install
-      - cp src/AppConfig.json.dist src/AppConfig.json
       - cp google-services.json.dist android/app/google-services.json
     script:
       - cd android && ./gradlew assembleDebug --stacktrace
@@ -48,7 +45,6 @@ matrix:
       - gem install xcpretty
       - npm install -g yarn
       - yarn install
-      - cp src/AppConfig.json.dist src/AppConfig.json
       - cd ios
     script:
       - xcodebuild -workspace CoopCycle.xcworkspace -scheme CoopCycle -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO | xcpretty && exit ${PIPESTATUS[0]}

--- a/README.md
+++ b/README.md
@@ -16,25 +16,18 @@ Install dependencies with Yarn, and link them with React Native CLI.
 ```
 $ yarn install
 $ sudo gem install cocoapods
-$ react-native link
 ```
-
-* Get a Google Map API Key and copy it. You will need to have the [
-Google Maps SDK for iOS](https://console.developers.google.com/apis/api/maps-ios-backend.googleapis.com/overview?project=coopcycle-dev-1495029274413&duration=PT1H) and [Google Maps Android API](https://console.developers.google.com/apis/api/maps-android-backend.googleapis.com/overview?project=coopcycle-dev-1495029274413&duration=PT1H) services enabled.
-* Create a Stripe account and copy your tests credentials.
-* Create the file AppConfig.json in ./src and copy the following lines, replacing **** by the corresponding API key:
-
-```
-{
-"GOOGLE_API_KEY": "****",
-"STRIPE_PUBLISHABLE_KEY": "****"
-}
-````
 
 Running on Android emulator
 -----------------------
 
 NB: You may need to open the Android project in Android Studio before it builds.
+
+* Get a Google Maps API Key
+
+A Google Maps API Key is needed at compilation time for Android (see `AndroidManifest.xml`).
+
+You will need to have the [Google Maps Android API](https://console.developers.google.com/apis/api/maps-android-backend.googleapis.com/overview?project=coopcycle-dev-1495029274413&duration=PT1H) service enabled.
 
 * Create a `gradle.properties` file in `GRADLE_USER_HOME` (defaults to `~/.gradle`)
 

--- a/src/AppConfig.js
+++ b/src/AppConfig.js
@@ -1,5 +1,7 @@
-import AppConfig from './AppConfig.json'
-
 module.exports = {
-    ...AppConfig
-};
+  GOOGLE_API_KEY: "",
+  STRIPE_PUBLISHABLE_KEY: "",
+  GCM_SENDER_ID: "",
+  LOCALE: "fr",
+  COUNTRY_NAME: "fr"
+}

--- a/src/AppConfig.json.dist
+++ b/src/AppConfig.json.dist
@@ -1,7 +1,0 @@
-{
-    "GOOGLE_API_KEY": "",
-    "STRIPE_PUBLISHABLE_KEY": "",
-    "GCM_SENDER_ID": "",
-    "LOCALE": "fr",
-    "COUNTRY_NAME": "fr"
-}

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -1,5 +1,6 @@
 import { AsyncStorage } from 'react-native'
 import EventEmitter from 'EventEmitter'
+import AppConfig from './AppConfig'
 
 let events = new EventEmitter()
 
@@ -98,6 +99,53 @@ class Settings {
         reject(error.message)
       }
     });
+  }
+
+  static saveServerSettings(settings) {
+    return new Promise((resolve, reject) => {
+      try {
+        AsyncStorage.setItem('@Settings.server', JSON.stringify(settings))
+          .then((error) => {
+            if (error) {
+              return reject(error)
+            }
+            resolve()
+          })
+      } catch (error) {
+        reject(error.message)
+      }
+    })
+  }
+
+  static initAppConfig() {
+    return new Promise((resolve, reject) => {
+      try {
+        AsyncStorage.getItem('@Settings.server')
+          .then((data, error) => {
+            if (error) {
+              return reject(error)
+            }
+
+            if (!data) {
+              return reject('No server settings found')
+            }
+
+            return JSON.parse(data)
+          })
+          .then(settings => {
+            Object.assign(AppConfig, {
+              GOOGLE_API_KEY: settings['google_api_key'],
+              STRIPE_PUBLISHABLE_KEY: settings['stripe_publishable_key'],
+              LOCALE: settings['locale'],
+              COUNTRY_NAME: settings['country'],
+              GCM_SENDER_ID: '',
+            })
+            resolve()
+          })
+      } catch (error) {
+        reject(error.message)
+      }
+    })
   }
 
 }

--- a/src/page/CreditCardPage.js
+++ b/src/page/CreditCardPage.js
@@ -17,10 +17,6 @@ import { translate } from 'react-i18next'
 import AppConfig from '../AppConfig'
 import { formatPrice } from '../Cart'
 
-Stripe.init({
-  publishableKey: AppConfig.STRIPE_PUBLISHABLE_KEY,
-});
-
 class CreditCardPage extends Component {
   constructor(props) {
     super(props);
@@ -29,6 +25,11 @@ class CreditCardPage extends Component {
       loading: false,
       params: {}
     };
+  }
+  componentDidMount() {
+    Stripe.init({
+      publishableKey: AppConfig.STRIPE_PUBLISHABLE_KEY,
+    });
   }
   _onClick() {
 


### PR DESCRIPTION
There is [a new endpoint](https://github.com/coopcycle/coopcycle-web/commit/aab79e6ee4bcebd2c348787eac8a32fc7ad6fb46) on the API to retrieve the settings for an instance. 

Each time the user chooses a new server, the settings are loaded & stored locally.
The same `AppConfig` class is initialized when the app starts. 

If the settings are not there, the user is forced to choose the server again. 