### PR TITLE
Bump target sdk version to API level 28

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:usesCleartextTraffic="true"/>
+</manifest>

--- a/android/app/src/debug/res/xml/react_native_config.xml
+++ b/android/app/src/debug/res/xml/react_native_config.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
-  <domain-config cleartextTrafficPermitted="true">
-    <domain includeSubdomains="false">localhost</domain>
-    <domain includeSubdomains="false">10.0.2.2</domain>
-    <domain includeSubdomains="false">10.0.3.2</domain>
-  </domain-config>
-</network-security-config>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         buildToolsVersion = "28.0.3"
         minSdkVersion = 18
         compileSdkVersion = 28
-        targetSdkVersion = 26
+        targetSdkVersion = 28
         supportLibVersion = "28.0.0"
         playServicesVersion = "15.0.1"
         googlePlayServicesVersion = playServicesVersion


### PR DESCRIPTION
Fixes https://github.com/coopcycle/coopcycle-app/issues/196

Bumped target sdk version to 28, as it's supported by React Native since version 0.59 https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#059 

I'm not sure if there is anything else that needs to be done in scope of this issue. There is a list of changes for API level 28 https://developer.android.com/about/versions/pie/android-9.0-changes-28 may be there is anything from it that is applicable to the app?