### PR TITLE
Provide 64 bits version for Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -110,7 +110,7 @@ android {
         versionCode 49
         versionName "0.15.0"
         ndk {
-            abiFilters "armeabi-v7a", "x86"
+            abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
         manifestPlaceholders = [
             tipsiStripeRedirectScheme: "coopcycle",


### PR DESCRIPTION
Fixes #193 

One consequence of this, is that the app becomes +13Mb bigger, due to 64-bit binaries (it would be 37Mb in total). If it becomes a problem, it's possible to start using existing setup for generating multiple APKs or add support for App Bundles, but that would work only for Google Play https://blog.swmansion.com/make-your-react-native-app-3x-smaller-44c993eda2c9