### PR TITLE
Use custom icons to distinguish pickup & dropoff markers

### DIFF
--- a/src/components/TaskList.js
+++ b/src/components/TaskList.js
@@ -9,6 +9,11 @@ import _ from 'lodash'
 import { withTranslation } from 'react-i18next'
 
 import { greenColor, lightGreyColor, redColor } from '../styles/common'
+import {
+  doneIconName,
+  failedIconName,
+  taskTypeIconName
+} from '../navigation/task/styles/common'
 
 const styles = StyleSheet.create({
   itemLeftRight: {
@@ -59,12 +64,12 @@ class TaskList extends Component {
     switch (task.status) {
       case 'DONE':
         return (
-          <Icon style={ iconStyle } name="checkmark" />
+          <Icon type="FontAwesome" name={ doneIconName } style={ iconStyle } />
         )
       case 'FAILED':
         iconStyle.push(styles.iconDanger)
         return (
-          <Icon style={ iconStyle } name="warning" />
+          <Icon type="FontAwesome" name={ failedIconName } style={ iconStyle } />
         )
       default:
         return (
@@ -77,26 +82,26 @@ class TaskList extends Component {
 
     return (
       <View style={{ flex: 1, height: 400, alignItems: 'center', justifyContent: 'center' }}>
-        <Icon name={ iconName } style={{ color: '#fff' }} />
+        <Icon type="FontAwesome" name={ iconName } style={{ color: '#fff' }} />
       </View>
     )
   }
 
   renderSwipeoutLeftButton() {
 
-    return this.renderSwipeoutButton(this.props.swipeOutLeftIconName || 'checkmark')
+    return this.renderSwipeoutButton(this.props.swipeOutLeftIconName || doneIconName)
   }
 
   renderSwipeoutRightButton() {
 
-    return this.renderSwipeoutButton(this.props.swipeOutRightIconName || 'warning')
+    return this.renderSwipeoutButton(this.props.swipeOutRightIconName || failedIconName)
   }
 
   renderItem(task) {
 
     const { width } = Dimensions.get('window')
 
-    const taskTypeIcon = task.type === 'PICKUP' ? 'cube' : 'arrow-down'
+    const taskTypeIcon = taskTypeIconName(task)
     const isCompleted = _.includes(['DONE', 'FAILED'], task.status)
 
     let itemLeftStyle = [ styles.itemLeftRight ]
@@ -173,7 +178,7 @@ class TaskList extends Component {
           <Grid style={{ paddingVertical: 10 }}>
             <Col size={ 1 } style={ itemLeftStyle }>
               <Row style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-                <Icon style={ iconStyle } name={ taskTypeIcon } />
+                <Icon type="FontAwesome" style={ iconStyle } name={ taskTypeIcon } />
               </Row>
               { isCompleted &&
               <Row style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>

--- a/src/components/TasksMapView.js
+++ b/src/components/TasksMapView.js
@@ -5,7 +5,7 @@ import {
   StyleSheet,
   Text,
   TouchableOpacity,
-  View
+  View,
 } from 'react-native'
 import {Callout, Marker} from 'react-native-maps'
 import ClusteredMapView from 'react-native-maps-super-cluster'
@@ -13,12 +13,22 @@ import Modal from 'react-native-modal'
 import {withTranslation} from 'react-i18next'
 
 import Settings from '../Settings'
-import {greenColor, greyColor, redColor, whiteColor} from '../styles/common'
+import {
+  greyColor,
+  whiteColor,
+} from '../styles/common'
 import {uniq} from 'lodash'
 import {Icon} from 'native-base'
+import {
+  doneIconName,
+  failedIconName,
+  markerBackgroundStyle,
+  markerContainer,
+  markerIconStyle,
+  taskTypeIconName,
+} from '../navigation/task/styles/common'
 
 const clusterContainerSize = 40
-const markerContainerSize = 32
 
 const styles = StyleSheet.create({
   map: {
@@ -37,11 +47,6 @@ const styles = StyleSheet.create({
     fontSize: 13,
     color: whiteColor,
     textAlign: 'center',
-  },
-  markerContainer: {
-    margin: 10,
-    alignItems: 'center',
-    justifyContent: 'center',
   },
   markerCallout: {
     padding: 5,
@@ -83,63 +88,6 @@ const edgePadding = {
   right: 20,
 }
 
-const todoColor = greyColor
-const doneColor = greenColor
-const failedColor = redColor
-
-const markerColor = task => {
-  switch (task.status) {
-    case 'DONE':
-      return doneColor
-    case 'FAILED':
-      return failedColor
-    default:
-      return todoColor
-  }
-}
-
-const markerBackgroundStyle = task => {
-  return {
-    width: markerContainerSize,
-    height: markerContainerSize,
-    backgroundColor: whiteColor,
-    borderColor: markerColor(task),
-    borderWidth: 2,
-    borderStyle: 'solid',
-    borderTopLeftRadius: markerContainerSize / 2,
-    borderTopRightRadius: markerContainerSize / 2,
-    borderBottomLeftRadius: markerContainerSize / 2,
-    borderBottomRightRadius: 0,
-    transform: [
-      { rotate: '45deg' },
-    ],
-  }
-}
-
-const markerIconStyle = task => {
-  return {
-    position: 'absolute',
-    fontSize: 24,
-    color: markerColor(task),
-  }
-}
-
-const taskTypeIconName = task => {
-  const name = task.type === 'PICKUP' ? 'cube' : 'arrow-down'
-  return name
-}
-
-const markerIconName = task => {
-  switch (task.status) {
-  case 'DONE':
-    return 'checkmark'
-  case 'FAILED':
-    return 'warning'
-  default:
-    return taskTypeIconName(task)
-  }
-}
-
 const hasSameLocation = markers => {
   const coordsArray = markers.map(m => `${m.location.latitude};${m.location.longitude}`)
   const coordsArrayUniq = uniq(coordsArray)
@@ -151,6 +99,17 @@ const addressName = task => {
   const customerName = task.address.firstName ? [ task.address.firstName, task.address.lastName ].join(' ') : null
 
   return task.address.name || customerName || task.address.streetAddress
+}
+
+const markerIconName = task => {
+  switch (task.status) {
+  case 'DONE':
+    return doneIconName
+  case 'FAILED':
+    return failedIconName
+  default:
+    return taskTypeIconName(task)
+  }
 }
 
 class TasksMapView extends Component {
@@ -249,9 +208,9 @@ class TasksMapView extends Component {
         coordinate={ task.address.geo }
         flat={ true }
         ref={ this.markers.get(task['@id']) }>
-        <View style={ styles.markerContainer }>
+        <View style={ markerContainer }>
           <View style={ markerBackgroundStyle(task) } />
-          <Icon style={ markerIconStyle(task) } name={ markerIconName(task) } />
+          <Icon type="FontAwesome" name={ markerIconName(task) } style={ markerIconStyle(task) } />
         </View>
         <Callout onPress={ () => this.onCalloutPress(task) }
           style={ [ styles.markerCallout, { width: Math.floor(width * 0.6666) } ] }>

--- a/src/components/TasksMapView.js
+++ b/src/components/TasksMapView.js
@@ -1,15 +1,24 @@
-import React, { Component } from 'react'
-import { FlatList, StyleSheet, Dimensions, View, Text, TouchableOpacity } from 'react-native'
-import { Marker, Callout } from 'react-native-maps'
+import React, {Component} from 'react'
+import {
+  Dimensions,
+  FlatList,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View
+} from 'react-native'
+import {Callout, Marker} from 'react-native-maps'
 import ClusteredMapView from 'react-native-maps-super-cluster'
 import Modal from 'react-native-modal'
-import { withTranslation } from 'react-i18next'
+import {withTranslation} from 'react-i18next'
 
 import Settings from '../Settings'
-import { greenColor, redColor, greyColor, whiteColor } from '../styles/common'
-import { uniq } from 'lodash'
+import {greenColor, greyColor, redColor, whiteColor} from '../styles/common'
+import {uniq} from 'lodash'
+import {Icon} from 'native-base'
 
 const clusterContainerSize = 40
+const markerContainerSize = 32
 
 const styles = StyleSheet.create({
   map: {
@@ -28,6 +37,11 @@ const styles = StyleSheet.create({
     fontSize: 13,
     color: whiteColor,
     textAlign: 'center',
+  },
+  markerContainer: {
+    margin: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   markerCallout: {
     padding: 5,
@@ -69,19 +83,61 @@ const edgePadding = {
   right: 20,
 }
 
-const pinColor = task => {
+const todoColor = greyColor
+const doneColor = greenColor
+const failedColor = redColor
 
-  let pinColor = greyColor
-
-  if (task.status === 'DONE') {
-    pinColor = greenColor
+const markerColor = task => {
+  switch (task.status) {
+    case 'DONE':
+      return doneColor
+    case 'FAILED':
+      return failedColor
+    default:
+      return todoColor
   }
+}
 
-  if (task.status === 'FAILED') {
-    pinColor = redColor
+const markerBackgroundStyle = task => {
+  return {
+    width: markerContainerSize,
+    height: markerContainerSize,
+    backgroundColor: whiteColor,
+    borderColor: markerColor(task),
+    borderWidth: 2,
+    borderStyle: 'solid',
+    borderTopLeftRadius: markerContainerSize / 2,
+    borderTopRightRadius: markerContainerSize / 2,
+    borderBottomLeftRadius: markerContainerSize / 2,
+    borderBottomRightRadius: 0,
+    transform: [
+      { rotate: '45deg' },
+    ],
   }
+}
 
-  return pinColor
+const markerIconStyle = task => {
+  return {
+    position: 'absolute',
+    fontSize: 24,
+    color: markerColor(task),
+  }
+}
+
+const taskTypeIconName = task => {
+  const name = task.type === 'PICKUP' ? 'cube' : 'arrow-down'
+  return name
+}
+
+const markerIconName = task => {
+  switch (task.status) {
+  case 'DONE':
+    return 'checkmark'
+  case 'FAILED':
+    return 'warning'
+  default:
+    return taskTypeIconName(task)
+  }
 }
 
 const hasSameLocation = markers => {
@@ -191,9 +247,12 @@ class TasksMapView extends Component {
         identifier={ task['@id'] }
         key={ task['@id'] }
         coordinate={ task.address.geo }
-        pinColor={ pinColor(task) }
         flat={ true }
         ref={ this.markers.get(task['@id']) }>
+        <View style={ styles.markerContainer }>
+          <View style={ markerBackgroundStyle(task) } />
+          <Icon style={ markerIconStyle(task) } name={ markerIconName(task) } />
+        </View>
         <Callout onPress={ () => this.onCalloutPress(task) }
           style={ [ styles.markerCallout, { width: Math.floor(width * 0.6666) } ] }>
           { task.address.name ? (<Text style={ styles.markerCalloutText }>{ task.address.name }</Text>) : null }

--- a/src/navigation/courier/Settings.js
+++ b/src/navigation/courier/Settings.js
@@ -16,6 +16,7 @@ import {
   selectTagNames,
   selectKeepAwake,
 } from '../../redux/Courier'
+import {doneIconName, failedIconName} from '../task/styles/common'
 
 const Settings = ({
     navigation,
@@ -36,7 +37,7 @@ const Settings = ({
           </ListItem>
           <ListItem icon>
             <Left>
-              <Icon name="checkmark" />
+              <Icon type="FontAwesome" name={doneIconName} />
             </Left>
             <Body>
               <Text>{ t('HIDE_DONE_TASKS') }</Text>
@@ -49,7 +50,7 @@ const Settings = ({
           </ListItem>
           <ListItem icon>
             <Left>
-              <Icon name="warning" />
+              <Icon type="FontAwesome" name={failedIconName} />
             </Left>
             <Body>
               <Text>{ t('HIDE_FAILED_TASKS') }</Text>

--- a/src/navigation/task/Complete.js
+++ b/src/navigation/task/Complete.js
@@ -18,6 +18,7 @@ import {
   markTaskDone,
   markTaskFailed } from '../../redux/Courier'
 import { greenColor, redColor } from '../../styles/common'
+import { doneIconName, failedIconName} from './styles/common'
 
 const DELETE_ICON_SIZE = 32
 const CONTENT_PADDING = 20
@@ -60,7 +61,7 @@ class CompleteTask extends Component {
     const { width } = Dimensions.get('window')
 
     const imageSize = (width - 64) / 2
-    const buttonIconName = success ? 'checkmark' : 'warning'
+    const buttonIconName = success ? doneIconName : failedIconName
     const footerBgColor = success ? greenColor : redColor
     const footerText = success ? this.props.t('VALIDATE') : this.props.t('MARK_FAILED')
     const onPress = success ? this.markTaskDone.bind(this) : this.markTaskFailed.bind(this)
@@ -119,7 +120,7 @@ class CompleteTask extends Component {
         <Footer style={{ alignItems: 'center', backgroundColor: footerBgColor }}>
           <TouchableOpacity style={ styles.buttonContainer } onPress={ onPress }>
             <View style={ styles.buttonTextContainer }>
-              <Icon name={ buttonIconName } style={{ color: '#fff', marginRight: 10 }} />
+              <Icon type="FontAwesome" name={ buttonIconName } style={{ color: '#fff', marginRight: 10 }} />
               <Text style={{ color: '#fff' }}>{ footerText }</Text>
             </View>
           </TouchableOpacity>

--- a/src/navigation/task/Task.js
+++ b/src/navigation/task/Task.js
@@ -11,10 +11,18 @@ import { phonecall } from 'react-native-communications'
 import { showLocation } from 'react-native-map-link'
 import _ from 'lodash'
 
-import { greenColor, greyColor, redColor } from '../../styles/common'
+import { greenColor, redColor } from '../../styles/common'
 import { selectTasks } from '../../redux/Courier'
+import {
+  doneIconName,
+  failedIconName,
+  markerBackgroundStyle, markerContainer,
+  markerIconStyle, taskTypeIconName,
+} from './styles/common'
 
 const isCompleted = task => task.status !== 'TODO'
+
+const markerIconName = task => taskTypeIconName(task)
 
 class Task extends Component {
 
@@ -140,16 +148,6 @@ class Task extends Component {
     )
   }
 
-  pinColor(task) {
-    let color = greyColor
-
-    if (task.tags.length > 0) {
-      color = task.tags[0].color
-    }
-
-    return color
-  }
-
   renderTaskDetail(item) {
 
     const { iconName, text, component, onPress } = item
@@ -185,7 +183,7 @@ class Task extends Component {
   renderSwipeoutLeftButton() {
     return (
       <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-        <Icon name="checkmark" style={{ color: '#fff' }} />
+        <Icon type="FontAwesome" name={ doneIconName } style={{ color: '#fff' }} />
       </View>
     )
 
@@ -194,7 +192,7 @@ class Task extends Component {
   renderSwipeoutRightButton() {
     return (
       <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-        <Icon name="warning" style={{ color: '#fff' }} />
+        <Icon type="FontAwesome" name={ failedIconName } style={{ color: '#fff' }} />
       </View>
     )
   }
@@ -210,7 +208,7 @@ class Task extends Component {
         <Footer>
           <View style={ [ styles.buttonContainer, { backgroundColor: greenColor } ] }>
             <View style={ styles.buttonTextContainer }>
-              <Icon name="checkmark" style={{ color: '#fff', marginRight: 10 }} />
+              <Icon type="FontAwesome" name={ doneIconName } style={{ color: '#fff', marginRight: 10 }} />
               <Text style={{ color: '#fff' }}>{this.props.t('COMPLETED')}</Text>
             </View>
           </View>
@@ -223,7 +221,7 @@ class Task extends Component {
         <Footer>
           <View style={ [ styles.buttonContainer, { backgroundColor: redColor } ] }>
             <View style={ styles.buttonTextContainer }>
-              <Icon name="warning" style={{ color: '#fff', marginRight: 10 }} />
+              <Icon type="FontAwesome" name={ failedIconName } style={{ color: '#fff', marginRight: 10 }} />
               <Text style={{ color: '#fff' }}>{this.props.t('FAILED')}</Text>
             </View>
           </View>
@@ -314,8 +312,11 @@ class Task extends Component {
           identifier={ task['@id'] }
           key={ task['@id'] }
           coordinate={ task.address.geo }
-          pinColor={ this.pinColor(task) }
           flat={ true }>
+          <View style={ markerContainer }>
+            <View style={ markerBackgroundStyle(task) } />
+            <Icon type="FontAwesome" name={ markerIconName(task) } style={ markerIconStyle(task) } />
+          </View>
         </MapView.Marker>
       </MapView>
     )

--- a/src/navigation/task/styles/common.js
+++ b/src/navigation/task/styles/common.js
@@ -1,0 +1,87 @@
+// Source file for common logic related to how task is presented to a user (UI)
+
+import {darkGreyColor, redColor, whiteColor} from '../../../styles/common'
+
+const doneIconName = 'check'
+const failedIconName = 'remove'
+
+const pickupIconName = 'cube'
+const dropOffIconName = 'arrow-down'
+
+const taskTypeIconName = task => task.type === 'PICKUP' ? pickupIconName : dropOffIconName
+
+
+const markerContainerSize = 32
+
+const markerColor = task => {
+  let color = darkGreyColor
+
+  if (task.tags.length > 0) {
+    color = task.tags[0].color
+  }
+
+  switch (task.status) {
+  case 'DONE':
+    return color
+  case 'FAILED':
+    return redColor
+  default:
+    return color
+  }
+}
+
+const markerOpacity = task => {
+  switch (task.status) {
+  case 'DONE':
+    return 0.4
+  case 'FAILED':
+    return 0.4
+  default:
+    return 1
+  }
+}
+
+const markerContainer = {
+  margin: 10,
+  alignItems: 'center',
+  justifyContent: 'center',
+}
+
+const markerBackgroundStyle = task => {
+  return {
+    width: markerContainerSize,
+    height: markerContainerSize,
+    backgroundColor: whiteColor,
+    borderColor: markerColor(task),
+    opacity: markerOpacity(task),
+    borderWidth: 2,
+    borderStyle: 'solid',
+    borderTopLeftRadius: markerContainerSize / 2,
+    borderTopRightRadius: markerContainerSize / 2,
+    borderBottomLeftRadius: markerContainerSize / 2,
+    borderBottomRightRadius: 0,
+    transform: [
+      {rotate: '45deg'},
+    ],
+  }
+}
+
+const markerIconStyle = task => {
+  return {
+    position: 'absolute',
+    fontSize: 24,
+    color: markerColor(task),
+    opacity: markerOpacity(task),
+  }
+}
+
+export {
+  doneIconName,
+  failedIconName,
+  pickupIconName,
+  dropOffIconName,
+  taskTypeIconName,
+  markerContainer,
+  markerBackgroundStyle,
+  markerIconStyle,
+}

--- a/src/styles/common.js
+++ b/src/styles/common.js
@@ -2,6 +2,7 @@
 
 let primaryColor = '#e4022d',
     whiteColor = '#fff',
+    darkGreyColor = '#424242',
     greyColor = '#95A5A6',
     lightGreyColor = '#ECF0F1',
     blueColor = '#3498DB',
@@ -20,12 +21,13 @@ export {
   primaryColor,
   whiteColor,
   greyColor,
+  lightGreyColor,
+  darkGreyColor,
   blueColor,
   headerFontSize,
   dateSelectHeaderHeight,
   calendarHeight,
   greenColor,
   redColor,
-  lightGreyColor,
   fontTitleName,
 }


### PR DESCRIPTION
Fixes https://github.com/coopcycle/coopcycle-app/issues/245

Added different icons for pickup and dropoff tasks. 

Use (almost) the same colors for the tasks in the list and on the map

Markers are darkgrey by default:
![Simulator Screen Shot - iPhone X - 2019-12-03 at 20 50 08](https://user-images.githubusercontent.com/1525555/70085709-17eec300-1611-11ea-9f06-f5afac26e8d1.png)

Or use a tag color:
![Simulator Screen Shot - iPhone X - 2019-12-03 at 20 47 49](https://user-images.githubusercontent.com/1525555/70085777-3f459000-1611-11ea-81b6-566a3d98eb8f.png)

