### PR TITLE
fix: patch security provider, to enable TLS 1.2 for older Android devices (fixes #744)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -221,6 +221,8 @@ dependencies {
 
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "com.google.android.gms:play-services-basement:$playServicesVersion"
+    implementation "com.google.android.gms:play-services-base:$playServicesVersion"
 
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/";

--- a/android/app/src/main/java/fr/coopcycle/MainApplication.java
+++ b/android/app/src/main/java/fr/coopcycle/MainApplication.java
@@ -1,12 +1,17 @@
 package fr.coopcycle;
 
-import android.app.Application;
 import android.content.Context;
+import android.content.Intent;
+
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;
+import com.google.android.gms.common.GoogleApiAvailability;
+import com.google.android.gms.security.ProviderInstaller;
+import com.google.android.gms.security.ProviderInstaller.ProviderInstallListener;
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
@@ -51,8 +56,21 @@ public class MainApplication extends MultiDexApplication implements ReactApplica
   @Override
   public void onCreate() {
     super.onCreate();
+    upgradeSecurityProvider();
     SoLoader.init(this, /* native exopackage */ false);
     initializeFlipper(this); // Remove this line if you don't want Flipper enabled
+  }
+
+  private void upgradeSecurityProvider() {
+    ProviderInstaller.installIfNeededAsync(this, new ProviderInstallListener() {
+      @Override
+      public void onProviderInstalled() {}
+
+      @Override
+      public void onProviderInstallFailed(int errorCode, Intent recoveryIntent) {
+        GoogleApiAvailability.getInstance().showErrorNotification(MainApplication.this, errorCode);
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
Fixes #744

This change patches the security provider, which is recommended [here](https://developer.android.com/training/articles/security-gms-provider) and has the side effect of resolving the connection issue for Android 4.4 and below (issue #744).