### PR TITLE
Change address autocomplete text input color based on selected theme

### DIFF
--- a/src/components/AddressAutocomplete.js
+++ b/src/components/AddressAutocomplete.js
@@ -383,10 +383,10 @@ class AddressAutocomplete extends Component {
         renderTextInput={ props => this.renderTextInput(props) }
         listStyle={{
           margin: 0,
-          backgroundColor: colorScheme === 'dark' ? 'black' : 'white'
+          backgroundColor: colorScheme === 'dark' ? 'black' : 'white',
         }}
         style={{
-          color: '#333',
+          color: colorScheme === 'dark' ? 'white' : '#333',
           borderColor: '#b9b9b9',
           borderRadius: 20,
           paddingVertical: 8,


### PR DESCRIPTION
In the autocomplete adress modal the input has a color that is not very visible for dark mode
<p align="center">
  <img height="400" src="https://user-images.githubusercontent.com/4819244/137344492-09f6603e-4528-4950-aac0-c1dd4e52d477.jpg">
</p>

With the fix now it looks like this:
<p align="center">
    <img height="400" src="https://user-images.githubusercontent.com/4819244/137345275-aa78cfa2-da65-4945-84a3-c48cf16e071d.jpg">
  <img height="400" src="https://user-images.githubusercontent.com/4819244/137345415-8df6ef2a-ba68-4143-bdda-02d236a078ed.jpg">
</p>
