### PR TITLE
New packages and weight section in task screen

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -396,6 +396,8 @@
         "MY_ORDER": "My order",
         "OR": "or",
         "MULTIPLE_SERVERS_IN_SAME_CITY_MODAL_TEXT": "There are more than one cooperative in your city, you can navigate between them using the tabs or by swiping left or right.",
-        "DO_NOT_SHOW_IT_AGAIN": "Don't show it again"
+        "DO_NOT_SHOW_IT_AGAIN": "Don't show it again",
+        "total_packages": "Total: {{count}} package",
+        "total_packages_plural": "Total: {{count}} packages"
     }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -396,6 +396,8 @@
         "GUEST_CHECKOUT_ORDER_EMAIL_HELP": "Para enviarle actualizaciones sobre su pedido",
         "GUEST_CHECK_EMAIL_FOR_ORDER_UPDATES": "Como ha elegido comprar como invitado, por favor revise sus emails para seguir el estado de su pedido",
         "MULTIPLE_SERVERS_IN_SAME_CITY_MODAL_TEXT": "Hay más de una cooperativa en tu ciudad, puedes navegar entre ellas utilizando las tabs o deslizando hacia la derecha o izquierda.",
-        "DO_NOT_SHOW_IT_AGAIN": "No volver a mostrar"
+        "DO_NOT_SHOW_IT_AGAIN": "No volver a mostrar",
+        "total_packages": "Total: {{count}} paquete",
+        "total_packages_plural": "Total: {{count}} paquetes"
     }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -378,6 +378,8 @@
         "GUEST_CHECKOUT_ORDER_EMAIL_HELP": "Pour vous envoyer des mises à jour à propos de votre commande",
         "GUEST_CHECK_EMAIL_FOR_ORDER_UPDATES": "Comme vous avez choisi de commander en tant qu'invité, veuillez vérifier vos e-mails pour suivre votre commande",
         "MY_ORDER": "Ma commande",
-        "OR": "ou"
+        "OR": "ou",
+        "total_packages": "Total : {{count}} paquet",
+        "total_packages_plural": "Total : {{count}} paquets"
     }
 }

--- a/src/navigation/task/components/Details.js
+++ b/src/navigation/task/components/Details.js
@@ -6,12 +6,13 @@ import { showLocation } from 'react-native-map-link'
 import { phonecall } from 'react-native-communications'
 import moment from 'moment'
 import Ionicons from 'react-native-vector-icons/Ionicons'
+import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons'
 
 import ItemSeparator from '../../../components/ItemSeparator'
 
 const Detail = ({ item }) => {
 
-  const { iconName, text, component, onPress } = item
+  const { iconType, iconName, text, component, onPress } = item
 
   let touchableOpacityProps = {}
   if (onPress) {
@@ -28,7 +29,7 @@ const Detail = ({ item }) => {
   return (
     <TouchableOpacity style={{ flex: 1 }} { ...touchableOpacityProps }>
       <HStack alignItems="center" justifyContent="center" p="2">
-        <Icon as={ Ionicons } name={ iconName } style={{ color: '#ccc' }} />
+        <Icon as={ iconType ? iconType : Ionicons } name={ iconName } style={{ color: '#ccc' }} />
         { body }
         { onPress &&
         <Icon as={ Ionicons } name="arrow-forward" style={{ color: '#ccc' }} />
@@ -97,6 +98,28 @@ const Details = ({ task, t }) => {
         )) }
         </View>
       ),
+    })
+  }
+
+  if (task.packages && task.packages.length) {
+    const packagesSummary = task.packages.reduce(({text, totalQuantity}, p) => {
+      const packageText = `${p.quantity} × ${p.package.name}`;
+      text = text.length ? `${text}\n${packageText}` : packageText;
+      totalQuantity += p.quantity;
+      return {text, totalQuantity};
+    }, {text: '', totalQuantity: 0});
+    items.push({
+      iconName: 'cube',
+      text: `${packagesSummary.text}`,
+      component: <Text fontWeight="bold">{t('total_packages', {count: packagesSummary.totalQuantity})}</Text>,
+    })
+  }
+
+  if (task.weight) {
+    items.push({
+      iconName: 'scale',
+      iconType: MaterialCommunityIcons,
+      text: `${(Number(task.weight) / 1000).toFixed(2)} kg`,
     })
   }
 


### PR DESCRIPTION
With these changes now we are showing in the pickup task all the packages and the weight from all subsequent dropoffs.
Also, on each dropoff task now we show the packages and weight to be delivered.

https://user-images.githubusercontent.com/4819244/153931540-57badfeb-cffb-42e2-a35f-7060ad3f86c0.mp4

For now we keep the packages and weight info in the pickup task comments because if some admin/courier has an old version of the app can still see this info in comments. But after a period, we are going to remove this behaviour and then comments won't include this info.
This is how it looks now with the info in comments too:
<img width="350" src="https://user-images.githubusercontent.com/4819244/153932406-ff1540b0-956d-4f49-87fd-7ccd2cded275.png"></img>
