### PR TITLE
Lazy loading / caching for restaurant screen.

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "react-native-vector-icons": "^9.1.0",
     "react-native-version-number": "^0.3.6",
     "react-navigation-header-buttons": "^9.0.1",
+    "react-query": "^3.34.19",
     "react-redux": "^7.2.6",
     "reduce-reducers": "^1.0.4",
     "redux": "^4.1.2",

--- a/src/App.js
+++ b/src/App.js
@@ -46,6 +46,7 @@ import DropdownAlert from 'react-native-dropdownalert'
 import DropdownHolder from './DropdownHolder'
 
 import NavigationHolder from './NavigationHolder'
+import {QueryClient, QueryClientProvider} from 'react-query';
 
 LogBox.ignoreLogs([
   'Warning: isMounted(...) is deprecated in plain JavaScript React classes.',
@@ -113,6 +114,8 @@ const App = () => {
     },
   })
 
+  const queryClient = new QueryClient()
+
   useEffect(() => {
     // https://support.count.ly/hc/en-us/articles/360037813231-React-Native-Bridge-#implementation
     // We will need to call two methods (init and start) in order to set up our SDK.
@@ -126,21 +129,23 @@ const App = () => {
     <Provider store={ store }>
       <PersistGate loading={ null } persistor={ persistor }>
         <I18nextProvider i18n={ i18n }>
-          <NativeBaseProvider theme={customTheme}>
-            <SafeAreaProvider>
-              <Spinner />
-              <NavigationContainer
-                ref={ navigationRef }
-                linking={ linking }
-                onReady={ () => (routeNameRef.current = navigationRef.current.getCurrentRoute()?.name) }
-                onStateChange={ onNavigationStateChange }
-                theme={ colorScheme === 'dark' ? DarkTheme : DefaultTheme }>
-                <Root />
-              </NavigationContainer>
-              <DropdownAlert ref={ ref => { DropdownHolder.setDropdown(ref) } } />
-              <NotificationHandler />
-            </SafeAreaProvider>
-          </NativeBaseProvider>
+          <QueryClientProvider client={queryClient}>
+            <NativeBaseProvider theme={customTheme}>
+              <SafeAreaProvider>
+                <Spinner />
+                <NavigationContainer
+                  ref={ navigationRef }
+                  linking={ linking }
+                  onReady={ () => (routeNameRef.current = navigationRef.current.getCurrentRoute()?.name) }
+                  onStateChange={ onNavigationStateChange }
+                  theme={ colorScheme === 'dark' ? DarkTheme : DefaultTheme }>
+                  <Root />
+                </NavigationContainer>
+                <DropdownAlert ref={ ref => { DropdownHolder.setDropdown(ref) } } />
+                <NotificationHandler />
+              </SafeAreaProvider>
+            </NativeBaseProvider>
+          </QueryClientProvider>
         </I18nextProvider>
       </PersistGate>
     </Provider>

--- a/src/navigation/checkout/ProductDetails.js
+++ b/src/navigation/checkout/ProductDetails.js
@@ -38,9 +38,10 @@ class ProductDetails extends Component {
 
     _onPressAddToCart() {
         const product = this.props.route.params?.product;
+        const restaurant = this.props.route.params?.restaurant;
 
-        this.props.addItem(product, this.state.quantity, this.state.optionsPayload);
-        this.props.navigation.navigate('CheckoutRestaurant', { restaurant: this.props.restaurant });
+        this.props.addItem(restaurant, product, this.state.quantity, this.state.optionsPayload);
+        this.props.navigation.navigate('CheckoutRestaurant', { restaurant });
     }
 
     optionsHasChanged({optionsPayload, optionsAreValid}) {
@@ -132,13 +133,13 @@ class ProductDetails extends Component {
 
 function mapStateToProps(state) {
     return {
-        restaurant: state.checkout.restaurant,
+
     }
 }
 
 function mapDispatchToProps(dispatch) {
     return {
-        addItem: (item, quantity, options) => dispatch(addItem(item, quantity, options)),
+        addItem: (restaurant, item, quantity, options) => dispatch(addItem(restaurant, item, quantity, options)),
     }
 }
 

--- a/src/navigation/checkout/Restaurant.js
+++ b/src/navigation/checkout/Restaurant.js
@@ -1,165 +1,174 @@
-import React, { Component } from 'react'
-import { ImageBackground, InteractionManager, StyleSheet, View, Animated } from 'react-native'
-import { connect } from 'react-redux'
-import { withTranslation } from 'react-i18next'
-import { Text } from 'native-base';
+import React from 'react'
+import {View} from 'react-native'
+import {connect} from 'react-redux'
+import {withTranslation} from 'react-i18next'
+import {Button, Center, Heading, HStack, Skeleton, Text, VStack} from 'native-base';
 import _ from 'lodash'
 import moment from 'moment'
 
 import CartFooter from './components/CartFooter'
-import AddressModal from './components/AddressModal'
 import ExpiredSessionModal from './components/ExpiredSessionModal'
 
 import Menu from '../../components/Menu'
 
-import { init, addItem, hideAddressModal, resetRestaurant, setAddress } from '../../redux/Checkout/actions'
+import { hideAddressModal, setAddress } from '../../redux/Checkout/actions'
 import DangerAlert from '../../components/DangerAlert';
-import { shouldShowPreOrder } from '../../utils/checkout'
+import {shouldShowPreOrder} from '../../utils/checkout'
+import {useQuery} from 'react-query';
+import i18n from '../../i18n';
+import GroupImageHeader from './components/GroupImageHeader';
+import AddressModal from './components/AddressModal';
 
-const GroupImageHeader = ({ restaurant, scale }) => {
-
-  return (
-    <Animated.View style={{
-      width: '100%',
-      height: '100%',
-      }}>
-      <ImageBackground source={{ uri: restaurant.image }} style={{ width: '100%', height: '100%' }}>
-        <View style={ styles.overlay }>
-          <View style={{ height: 60, justifyContent: 'center' }}>
-            <Text style={ styles.restaurantName } numberOfLines={ 1 }>{ restaurant.name }</Text>
-          </View>
-        </View>
-      </ImageBackground>
-    </Animated.View>
-  );
-};
+// Fix: key prop warning
+// https://github.com/GeekyAnts/NativeBase/issues/4473
+const LoadingPhantom = () => <Center w="100%">
+  <HStack w="95%" space={8} p="4">
+    <VStack flex="3" space="4">
+      <Skeleton flex={1} />
+      <Skeleton.Text flex={1} noOfLines={2} lineHeight={2} />
+      <HStack space="2" alignItems="center">
+        <Skeleton size="4" rounded="full" />
+        <Skeleton h="3" flex="2" rounded="full" />
+        <Skeleton h="3" flex="1" rounded="full" startColor="cyan.300" />
+      </HStack>
+    </VStack>
+    <Skeleton flex="1" h="100" w="100" rounded="md" />
+  </HStack>
+  <HStack w="95%" space={8} p="4">
+    <VStack flex="3" space="4">
+      <Skeleton flex={1} />
+      <Skeleton.Text flex={1} noOfLines={2} lineHeight={2} />
+      <HStack space="2" alignItems="center">
+        <Skeleton size="4" rounded="full" />
+        <Skeleton h="3" flex="2" rounded="full" />
+        <Skeleton h="3" flex="1" rounded="full" />
+      </HStack>
+    </VStack>
+    <Skeleton flex="1" h="100" w="100" rounded="md" />
+  </HStack>
+  <HStack w="95%" space={8} p="4">
+    <VStack flex="3" space="4">
+      <Skeleton flex={1} />
+      <Skeleton.Text flex={1} noOfLines={2} lineHeight={2} />
+      <HStack space="2" alignItems="center">
+        <Skeleton size="4" rounded="full" />
+        <Skeleton h="3" flex="2" rounded="full" />
+        <Skeleton h="3" flex="1" rounded="full" startColor="amber.300" />
+      </HStack>
+    </VStack>
+    <Skeleton flex="1" h="100" w="100" rounded="md" />
+  </HStack>
+</Center>
 
 function hasValidTiming(timing) {
   return timing !== null && timing.range[0] !== timing.range[1]
 }
-class Restaurant extends Component {
 
-  constructor(props) {
-    super(props)
-    this.state = {
-      scrollOffsetY: new Animated.Value(0),
-      isAvailable: (hasValidTiming(this.props.route.params?.restaurant.timing.collection)) ||
-        hasValidTiming(this.props.route.params?.restaurant.timing.delivery),
-    }
-    this.scrollOffsetY = new Animated.Value(0)
-  }
-
-  componentDidMount() {
-    this.props.resetRestaurant(this.props.route.params?.restaurant)
-    InteractionManager.runAfterInteractions(() => {
-      this.props.init(this.props.route.params?.restaurant)
-    })
-  }
-
-  renderNotAvailableWarning(restaurant) {
-    if (!this.state.isAvailable) {
-        return (
-          <DangerAlert
-            text={`${this.props.t('RESTAURANT_CLOSED_AND_NOT_AVAILABLE', {
-              datetime: moment(restaurant.nextOpeningDate).calendar(moment(), {
-                sameElse: 'llll',
-              }),
-            })}`}
-          />
-        )
-    }
-  }
-
-  renderClosedNowWarning(restaurant) {
-    if (this.state.isAvailable && shouldShowPreOrder(restaurant) && restaurant.nextOpeningDate) {
-      return (
-        <DangerAlert
-          adjustsFontSizeToFit={true}
-          text={`${this.props.t('RESTAURANT_CLOSED_BUT_OPENS', {
-            datetime: moment(restaurant.nextOpeningDate).calendar(moment(), {
-              sameElse: 'llll',
-            }),
-          })}`}
-        />
-      )
-    }
-  }
-
-  render() {
-
-    const { navigate } = this.props.navigation
-    const restaurant = this.props.route.params?.restaurant
-    const { isCartEmpty, menu } = this.props
-
+function renderNotAvailableWarning(restaurant, isAvailable) {
+  if (isAvailable) {
     return (
-      <View style={{ flex: 1 }}>
-        <View style={{ flex: 1, paddingTop: 60 }}>
-          <View style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: 60 }}>
-            <GroupImageHeader restaurant={ restaurant } />
-          </View>
-          {this.renderNotAvailableWarning(restaurant)}
-          {this.renderClosedNowWarning(restaurant)}
-          <Menu
-            restaurant={ restaurant }
-            menu={ menu }
-            onItemClick={ menuItem => navigate('CheckoutProductDetails', { product: menuItem }) }
-            isItemLoading={ menuItem => {
-              return _.includes(this.props.loadingItems, menuItem.identifier)
-            } } />
-        </View>
-        { !isCartEmpty && (
-        <CartFooter
-          onSubmit={ () => navigate('CheckoutSummary') }
-          testID="cartSubmit"
-          disabled={ this.props.isLoading } />
-        )}
-        <AddressModal
-          onGoBack={ (address) => {
-            this.props.hideAddressModal()
-            navigate('CheckoutHome', { address })
-          }} />
-        <ExpiredSessionModal
-          onModalHide={ () => navigate('CheckoutHome') } />
-      </View>
+      <DangerAlert
+        text={`${i18n.t('RESTAURANT_CLOSED_AND_NOT_AVAILABLE', {
+          datetime: moment(restaurant.nextOpeningDate).calendar(moment(), {
+            sameElse: 'llll',
+          }),
+        })}`}
+      />
     )
   }
 }
 
-const styles = StyleSheet.create({
-  overlay: {
-    position: 'absolute',
-    width: '100%',
-    height: '100%',
-    backgroundColor:'rgba(0,0,0,0.5)',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  restaurantName: {
-    color: '#ffffff',
-    fontFamily: 'Raleway-Regular',
-    fontWeight: 'bold',
-  },
-});
+function renderClosedNowWarning(restaurant, isAvailable) {
+  if (isAvailable && shouldShowPreOrder(restaurant) && restaurant.nextOpeningDate) {
+    return (
+      <DangerAlert
+        adjustsFontSizeToFit={true}
+        text={`${i18n.t('RESTAURANT_CLOSED_BUT_OPENS', {
+          datetime: moment(restaurant.nextOpeningDate).calendar(moment(), {
+            sameElse: 'llll',
+          }),
+        })}`}
+      />
+    )
+  }
+}
 
-function mapStateToProps(state) {
+function Restaurant(props) {
+  const { navigate } = props.navigation
+  const { showFooter, httpClient, restaurant } = props
+  const nextOpeningDateCheck = _.has(restaurant, 'nextOpeningDate')
+  const isAvailable = (hasValidTiming(restaurant.timing.collection)) ||
+  hasValidTiming(restaurant.timing.delivery)
 
+  const { isLoading, isError, data } = useQuery(['menus', restaurant.hasMenu], async () => {
+    return await httpClient.get(restaurant.hasMenu, {}, { anonymous: true })
+  })
+
+  //TODO: improve failed view
+  if (isError) {
+    return <Center w="95%">
+      <Heading>{i18n.t('AN_ERROR_OCCURRED')} </Heading>
+      <Text>{i18n.t('TRY_LATER')}</Text>
+      <Button>{i18n.t('RETRY')}</Button>
+    </Center>
+  }
+
+  return (
+    <View style={{ flex: 1 }}>
+      <View style={{ flex: 1, paddingTop: 60 }}>
+        <View style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: 60 }}>
+          <GroupImageHeader image={ restaurant.image } text={restaurant.name} />
+        </View>
+        { nextOpeningDateCheck && renderNotAvailableWarning(restaurant, isAvailable) }
+        { nextOpeningDateCheck && renderClosedNowWarning(restaurant, isAvailable) }
+        { isLoading && LoadingPhantom() }
+        { !isLoading && <Menu
+          restaurant={ restaurant }
+          menu={ data }
+          onItemClick={ menuItem => navigate('CheckoutProductDetails', { product: menuItem, restaurant }) }
+          isItemLoading={ menuItem => props.loadingItems.includes(menuItem.identifier) } /> }
+      </View>
+      { showFooter && (
+        <CartFooter
+          onSubmit={ () => navigate('CheckoutSummary', { restaurant }) }
+          cart={props.cart}
+          initLoading={props.cartLoading}
+          testID="cartSubmit"
+          disabled={ isLoading } />
+      ) }
+      <AddressModal
+        onGoBack={ (address) => {
+          this.props.hideAddressModal()
+          navigate('CheckoutHome', { address })
+        }} />
+      <ExpiredSessionModal
+        onModalHide={ () => navigate('CheckoutHome') } />
+    </View>
+  )
+}
+
+function mapStateToProps(state, ownProps) {
+
+  const restaurant = ownProps.route.params?.restaurant
+  const cart = state.checkout.cart
+  const cartLoading = state.checkout.isLoading
   const isCartEmpty = !state.checkout.cart ? true : state.checkout.cart.items.length === 0
+  const isSameRestaurant = restaurant['@id'] === cart?.restaurant
 
   return {
-    isCartEmpty,
-    menu: state.checkout.menu,
+    showFooter: isSameRestaurant && (cartLoading || !isCartEmpty),
+    cartLoading,
+    restaurant,
+    cart,
     address: state.checkout.address,
-    isLoading: state.checkout.isLoading,
     loadingItems: state.checkout.itemRequestStack,
     isExpiredSessionModalVisible: state.checkout.isExpiredSessionModalVisible,
+    httpClient: state.app.httpClient,
   }
 }
 
 function mapDispatchToProps(dispatch) {
   return {
-    init: restaurant => dispatch(init(restaurant)),
-    resetRestaurant: restaurant => dispatch(resetRestaurant(restaurant)),
-    addItem: item => dispatch(addItem(item)),
     setAddress: address => dispatch(setAddress(address)),
     hideAddressModal: () => dispatch(hideAddressModal()),
   }

--- a/src/navigation/checkout/Summary.js
+++ b/src/navigation/checkout/Summary.js
@@ -203,6 +203,7 @@ class Summary extends Component {
     return (
       <CartFooter
         onSubmit={ this.onSubmit.bind(this) }
+        cart={ cart }
         testID="cartSummarySubmit"
         disabled={ this.props.isValid !== true || this.props.isLoading } />
     )

--- a/src/navigation/checkout/components/CartFooter.js
+++ b/src/navigation/checkout/components/CartFooter.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { View } from 'react-native'
-import { HStack } from 'native-base'
+import { HStack, Skeleton } from 'native-base'
 import { connect } from 'react-redux'
 import { withTranslation } from 'react-i18next'
 import PropTypes from 'prop-types'
@@ -11,17 +11,19 @@ class CartFooter extends Component {
 
   render() {
 
-    const { cart } = this.props
+    const { cart, initLoading } = this.props
 
     return (
       <HStack testID="cartFooter">
         <View style={{ flex: 1, alignItems: 'center', paddingHorizontal: 5, paddingVertical: 5 }}>
-          <CartFooterButton
+          {initLoading && <Skeleton h="10" w={'100%'} startColor={'cyan.500'} />}
+          {!initLoading && <CartFooterButton
             cart={ cart }
             onPress={ () => this.props.onSubmit() }
             loading={ this.props.isLoading }
             testID={ this.props.testID }
             disabled={  this.props.disabled } />
+          }
         </View>
       </HStack>
     )
@@ -37,11 +39,9 @@ CartFooter.propTypes = {
   disabled: PropTypes.bool,
 }
 
-function mapStateToProps(state) {
-
+function mapStateToProps(state, ownProps) {
   return {
     isLoading: state.checkout.isLoading,
-    cart: state.checkout.cart,
   }
 }
 

--- a/src/navigation/checkout/components/GroupImageHeader.js
+++ b/src/navigation/checkout/components/GroupImageHeader.js
@@ -1,0 +1,32 @@
+import {Animated, ImageBackground, StyleSheet, View} from 'react-native';
+import {Text} from 'native-base';
+import React from 'react';
+const styles = StyleSheet.create({
+  overlay: {
+    position: 'absolute',
+    width: '100%',
+    height: '100%',
+    backgroundColor:'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  restaurantName: {
+    color: '#ffffff',
+    fontFamily: 'Raleway-Regular',
+    fontWeight: 'bold',
+  },
+});
+export default (props) => {
+  return <Animated.View style={{
+    width: '100%',
+    height: '100%',
+  }}>
+    <ImageBackground source={{ uri: props.image }} style={{ width: '100%', height: '100%' }}>
+      <View style={ styles.overlay }>
+        <View style={{ height: 60, justifyContent: 'center' }}>
+          <Text style={ styles.restaurantName } numberOfLines={ 1 }>{ props.text }</Text>
+        </View>
+      </View>
+    </ImageBackground>
+  </Animated.View>
+}

--- a/src/redux/Checkout/reducers.js
+++ b/src/redux/Checkout/reducers.js
@@ -142,7 +142,6 @@ export default (state = initialState, action = {}) => {
         isFetching: false,
         restaurant: action.payload.restaurant,
         cart: action.payload.cart,
-        menu: action.payload.restaurant.hasMenu,
         token: action.payload.token,
         isAddressOK: null, // We don't know if it's valid
         itemRequestStack: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1125,6 +1125,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2":
+  version "7.17.8"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.8.tgz#3e56e4aff81befa55ac3ac6a0967349fd1c5bca2"
+  integrity sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.8.7":
   version "7.16.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.5.tgz#7f3e34bf8bdbbadf03fbb7b1ea0d929569c9487a"
@@ -5125,7 +5132,7 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
-big-integer@1.6.x, big-integer@^1.6.7:
+big-integer@1.6.x, big-integer@^1.6.16, big-integer@^1.6.7:
   version "1.6.51"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
   integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
@@ -5208,6 +5215,20 @@ braces@^3.0.1:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
@@ -6135,6 +6156,11 @@ detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
+detect-node@^2.0.4, detect-node@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
+  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
 detox@^19.6.5:
   version "19.6.5"
@@ -8727,6 +8753,11 @@ joi@^17.2.1:
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -9271,6 +9302,14 @@ markdown-it@^10.0.0:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
+match-sorter@^6.0.2:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.1.tgz#98cc37fda756093424ddf3cbc62bfe9c75b92bda"
+  integrity sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 md5-file@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/md5-file/-/md5-file-3.2.3.tgz#f9bceb941eca2214a4c0727f5e700314e770f06f"
@@ -9700,6 +9739,11 @@ micromatch@^4.0.2, micromatch@^4.0.4:
     braces "^3.0.1"
     picomatch "^2.2.3"
 
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
+
 mime-db@1.51.0, "mime-db@>= 1.43.0 < 2":
   version "1.51.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
@@ -9877,6 +9921,13 @@ nan@^2.14.0:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
   integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@^3.1.23:
   version "3.1.25"
@@ -10248,6 +10299,11 @@ object.values@^1.1.1, object.values@^1.1.2, object.values@^1.1.5:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -11274,6 +11330,15 @@ react-navigation-header-buttons@^9.0.1:
   dependencies:
     invariant ">=2"
 
+react-query@^3.34.19:
+  version "3.34.19"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.34.19.tgz#0ff049b6e0d2ed148e9abfdd346625d0e88dc229"
+  integrity sha512-JO0Ymi58WKmvnhgg6bGIrYIeKb64KsKaPWo8JcGnmK2jJxAs2XmMBzlP75ZepSU7CHzcsWtIIyhMrLbX3pb/3w==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-redux@^7.2.6:
   version "7.2.6"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.6.tgz#49633a24fe552b5f9caf58feb8a138936ddfe9aa"
@@ -11543,6 +11608,11 @@ regjsparser@^0.7.0:
   dependencies:
     jsesc "~0.5.0"
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -11661,17 +11731,17 @@ rimraf@2.6.3, rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.5.4:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.0, rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -12926,6 +12996,14 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This is a sub-feature extraction of the changes made by @r0xsh for Naofood. 

It uses `react-query` to cache the restaurant menus, so that it loads instantly when navigating to a restaurant twice. 
It removes the usage of the global spinner overlay, and uses [placeholders](https://docs.nativebase.io/skeleton) instead. 

The session is now created "lazily", when calling `addItem`. 
As a result, when re-entering the same restaurant the cart was already created on, it loads instantly. 

![restaurant_lazy](https://user-images.githubusercontent.com/1162230/177321926-c53b9933-ebb4-47d1-adf5-e713e7640d3e.gif)
.