### PR TITLE
Improve terms and privacy policy

### DIFF
--- a/src/components/AuthenticateForm.js
+++ b/src/components/AuthenticateForm.js
@@ -44,7 +44,7 @@ class AuthenticateForm extends Component {
     const btnLabel = formToDisplay === 'login' ? 'OR_REGISTER' : 'OR_LOGIN'
 
     return (
-      <View>
+      <View flex={1} style={{ width: '80%' }} justifyContent="center">
         { this.renderForm() }
         <View style={{ marginTop: 10 }}>
           <Button size="sm" variant="link" onPress={() => this.setState({ formToDisplay: alternateForm, message: '' })} testID="loginOrRegister">

--- a/src/components/LegalText.js
+++ b/src/components/LegalText.js
@@ -15,28 +15,12 @@ class LegalText extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      text: null,
       showConfirmationButtons: this.props.showConfirmationButtons,
     }
 
     this.scrollRef = React.createRef()
 
     this._handleNav = this._handleNav.bind(this)
-  }
-
-  componentDidMount() {
-    axios
-      .get(`https://coopcycle.org/${this.props.type}/${this.props.language}.md`)
-      .then((response) => {
-        this.setState({ text: response.data })
-      })
-      .catch(e => {
-        axios
-          .get(`https://coopcycle.org/${this.props.type}/en.md`)
-          .then((response) => {
-            this.setState({ text: response.data })
-          })
-      })
   }
 
   componentDidUpdate() {
@@ -47,7 +31,7 @@ class LegalText extends Component {
     if (nextProps.showConfirmationButtons !== prevState.showConfirmationButtons) {
       // reload component data if prop has changed
       return {
-        text: prevState.text, // keep text to avoid a new api call
+        ...prevState,
         showConfirmationButtons: nextProps.showConfirmationButtons,
       }
     }
@@ -55,6 +39,7 @@ class LegalText extends Component {
   }
 
   _handleNav({ legalTextAccepted }) {
+    // we should call to a prop function and component using this should determine which dispatch execute
     if (this.props.type === 'terms') {
       this.props.acceptTermsAndConditions(legalTextAccepted)
     } else if (this.props.type === 'privacy') {
@@ -65,7 +50,7 @@ class LegalText extends Component {
 
   render() {
 
-    if (!this.state.text) {
+    if (this.props.loading) {
 
       return (
         <Center flex={1}>
@@ -83,7 +68,7 @@ class LegalText extends Component {
           px="4"
         >
           <Markdown>
-            {this.state.text}
+            {this.props.text}
           </Markdown>
           {
             this.props.showConfirmationButtons &&
@@ -102,13 +87,6 @@ class LegalText extends Component {
   }
 }
 
-function mapStateToProps(state) {
-
-  return {
-    language: localeDetector(),
-  }
-}
-
 function mapDispatchToProps(dispatch) {
   return {
     acceptTermsAndConditions: (accepted) => dispatch(acceptTermsAndConditions(accepted)),
@@ -116,4 +94,4 @@ function mapDispatchToProps(dispatch) {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(withTranslation()(LegalText))
+export default connect(() => ({}), mapDispatchToProps)(withTranslation()(LegalText))

--- a/src/components/LegalText.js
+++ b/src/components/LegalText.js
@@ -1,12 +1,14 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { Center, ScrollView, Spinner } from 'native-base'
+import { Button, Center, Row, ScrollView, Spinner } from 'native-base'
 import { withTranslation } from 'react-i18next'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import axios from 'axios'
 import Markdown from 'react-native-markdown-display'
 
 import { localeDetector } from '../i18n'
+import NavigationHolder from '../NavigationHolder'
+import { acceptPrivacyPolicy, acceptTermsAndConditions } from '../redux/App/actions'
 
 class LegalText extends Component {
 
@@ -14,7 +16,12 @@ class LegalText extends Component {
     super(props)
     this.state = {
       text: null,
+      showConfirmationButtons: this.props.showConfirmationButtons,
     }
+
+    this.scrollRef = React.createRef()
+
+    this._handleNav = this._handleNav.bind(this)
   }
 
   componentDidMount() {
@@ -32,12 +39,36 @@ class LegalText extends Component {
       })
   }
 
+  componentDidUpdate() {
+    this.scrollRef?.current?.scrollTo({ x: 0, y: 0, animated: false });
+  }
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.showConfirmationButtons !== prevState.showConfirmationButtons) {
+      // reload component data if prop has changed
+      return {
+        text: prevState.text, // keep text to avoid a new api call
+        showConfirmationButtons: nextProps.showConfirmationButtons,
+      }
+    }
+    return prevState;
+  }
+
+  _handleNav({ legalTextAccepted }) {
+    if (this.props.type === 'terms') {
+      this.props.acceptTermsAndConditions(legalTextAccepted)
+    } else if (this.props.type === 'privacy') {
+      this.props.acceptPrivacyPolicy(legalTextAccepted)
+    }
+    NavigationHolder.goBack()
+  }
+
   render() {
 
     if (!this.state.text) {
 
       return (
-        <Center flex={ 1 }>
+        <Center flex={1}>
           <Spinner size="lg" />
         </Center>
       )
@@ -46,13 +77,25 @@ class LegalText extends Component {
     return (
       <SafeAreaView>
         <ScrollView
+          ref={this.scrollRef}
           contentInsetAdjustmentBehavior="automatic"
           style={{ height: '100%' }}
           px="4"
         >
           <Markdown>
-            { this.state.text }
+            {this.state.text}
           </Markdown>
+          {
+            this.props.showConfirmationButtons &&
+            <Row justifyContent="space-between" space={10} my={4}>
+              <Button onPress={() => this._handleNav({ legalTextAccepted: false })}>
+                {this.props.t('CANCEL')}
+              </Button>
+              <Button flex={1} colorScheme="success" onPress={() => this._handleNav({ legalTextAccepted: true })}>
+                {this.props.t('AGREE')}
+              </Button>
+            </Row>
+          }
         </ScrollView>
       </SafeAreaView>
     )
@@ -66,4 +109,11 @@ function mapStateToProps(state) {
   }
 }
 
-export default connect(mapStateToProps)(withTranslation()(LegalText))
+function mapDispatchToProps(dispatch) {
+  return {
+    acceptTermsAndConditions: (accepted) => dispatch(acceptTermsAndConditions(accepted)),
+    acceptPrivacyPolicy: (accepted) => dispatch(acceptPrivacyPolicy(accepted)),
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(withTranslation()(LegalText))

--- a/src/components/LegalText.js
+++ b/src/components/LegalText.js
@@ -1,22 +1,15 @@
 import React, { Component } from 'react'
-import { connect } from 'react-redux'
 import { Button, Center, Row, ScrollView, Spinner } from 'native-base'
 import { withTranslation } from 'react-i18next'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import axios from 'axios'
 import Markdown from 'react-native-markdown-display'
 
-import { localeDetector } from '../i18n'
 import NavigationHolder from '../NavigationHolder'
-import { acceptPrivacyPolicy, acceptTermsAndConditions } from '../redux/App/actions'
 
 class LegalText extends Component {
 
   constructor(props) {
     super(props)
-    this.state = {
-      showConfirmationButtons: this.props.showConfirmationButtons,
-    }
 
     this.scrollRef = React.createRef()
 
@@ -27,24 +20,8 @@ class LegalText extends Component {
     this.scrollRef?.current?.scrollTo({ x: 0, y: 0, animated: false });
   }
 
-  static getDerivedStateFromProps(nextProps, prevState) {
-    if (nextProps.showConfirmationButtons !== prevState.showConfirmationButtons) {
-      // reload component data if prop has changed
-      return {
-        ...prevState,
-        showConfirmationButtons: nextProps.showConfirmationButtons,
-      }
-    }
-    return prevState;
-  }
-
   _handleNav({ legalTextAccepted }) {
-    // we should call to a prop function and component using this should determine which dispatch execute
-    if (this.props.type === 'terms') {
-      this.props.acceptTermsAndConditions(legalTextAccepted)
-    } else if (this.props.type === 'privacy') {
-      this.props.acceptPrivacyPolicy(legalTextAccepted)
-    }
+    this.props.dispatchAccept(legalTextAccepted)
     NavigationHolder.goBack()
   }
 
@@ -87,11 +64,4 @@ class LegalText extends Component {
   }
 }
 
-function mapDispatchToProps(dispatch) {
-  return {
-    acceptTermsAndConditions: (accepted) => dispatch(acceptTermsAndConditions(accepted)),
-    acceptPrivacyPolicy: (accepted) => dispatch(acceptPrivacyPolicy(accepted)),
-  }
-}
-
-export default connect(() => ({}), mapDispatchToProps)(withTranslation()(LegalText))
+export default withTranslation()(LegalText)

--- a/src/components/RegisterForm.js
+++ b/src/components/RegisterForm.js
@@ -7,7 +7,7 @@ import _ from 'lodash'
 import { Formik } from 'formik'
 import { connect } from 'react-redux'
 
-import { navigate } from '../App'
+import NavigationHolder from '../NavigationHolder'
 import i18n from '../i18n'
 
 // Custom validator for matches
@@ -162,7 +162,8 @@ class RegisterForm extends React.Component {
       allErrors,
       setFieldValue,
       handleBlur,
-      this.props.t('TERMS_AND_CONDITIONS_BUTTON_LABEL')
+      this.props.t('TERMS_AND_CONDITIONS_BUTTON_LABEL'),
+      'TermsNav'
     )
 
     const privacyPolicyField = this._renderLegalField(
@@ -173,7 +174,8 @@ class RegisterForm extends React.Component {
       allErrors,
       setFieldValue,
       handleBlur,
-      this.props.t('PRIVACY_POLICY_BUTTON_LABEL')
+      this.props.t('PRIVACY_POLICY_BUTTON_LABEL'),
+      'PrivacyNav'
     )
 
     return (
@@ -224,18 +226,18 @@ class RegisterForm extends React.Component {
           ?
             <FormControl.HelperText>
               <Button size="sm" variant="link" testID={`${fieldName}Link`}
-                onPress={ () => navigate(buttonNavigation) }>
+                onPress={ () => NavigationHolder.navigate(buttonNavigation) }>
                 { buttonLabel }
               </Button>
             </FormControl.HelperText>
           :
             <FormControl.HelperText>
               <Button size="sm" variant="link" testID="termsAndConditionsLink"
-                onPress={ () => navigate('TermsNav') }>
+                onPress={ () => NavigationHolder.navigate('TermsNav') }>
                 { this.props.t('TERMS_AND_CONDITIONS_BUTTON_LABEL') }
               </Button>
               <Button size="sm" variant="link" testID="privacyPolicyLink"
-                onPress={ () => navigate('PrivacyNav') }>
+                onPress={ () => NavigationHolder.navigate('PrivacyNav') }>
                 { this.props.t('PRIVACY_POLICY_BUTTON_LABEL') }
               </Button>
             </FormControl.HelperText>

--- a/src/components/RegisterForm.js
+++ b/src/components/RegisterForm.js
@@ -115,7 +115,39 @@ class RegisterForm extends React.Component {
   constructor(props) {
     super(props)
 
+    this.state = {
+      termsAndConditionsAccepted: false,
+      privacyPolicyAccepted: false,
+    }
+
     this._inputComponents = new Map()
+
+    this._setTermsAndConditionsValue = null
+    this._setPrivacyPolicyValue = null
+  }
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.termsAndConditionsAccepted !== prevState.termsAndConditionsAccepted) {
+      return {
+        ...prevState,
+        termsAndConditionsAccepted: nextProps.termsAndConditionsAccepted,
+      }
+    } else if (nextProps.privacyPolicyAccepted !== prevState.privacyPolicyAccepted) {
+      return {
+        ...prevState,
+        privacyPolicyAccepted: nextProps.privacyPolicyAccepted,
+      }
+    }
+    return prevState;
+  }
+
+  componentDidUpdate() {
+    if (this.props.termsAndConditionsAccepted !== this.state.termsAndConditionsAccepted) {
+      this._setTermsAndConditionsValue(this.props.termsAndConditionsAccepted)
+    }
+    if (this.props.privacyPolicyAccepted !== this.state.privacyPolicyAccepted) {
+      this._setPrivacyPolicyValue(this.props.privacyPolicyAccepted)
+    }
   }
 
   renderError(message) {
@@ -179,6 +211,14 @@ class RegisterForm extends React.Component {
       'Privacy'
     )
 
+    this._setTermsAndConditionsValue = (value) => {
+      setFieldValue('termsAndConditions', value)
+    }
+
+    this._setPrivacyPolicyValue = (value) => {
+      setFieldValue('privacyPolicy', value)
+    }
+
     return (
       <>
         { termsAndConditionsField }
@@ -215,8 +255,10 @@ class RegisterForm extends React.Component {
 
       if (this.props.splitTermsAndConditionsAndPrivacyPolicy) {
         if (fieldName === 'termsAndConditions') {
+          this.setState({ termsAndConditionsAccepted: checked })
           this.props.acceptTermsAndConditions(checked)
         } else if (fieldName === 'privacyPolicy') {
+          this.setState({ privacyPolicyAccepted: checked })
           this.props.acceptPrivacyPolicy(checked)
         }
 

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -401,6 +401,14 @@
         "total_packages_plural": "Total: {{count}} paquetes",
         "RESTAURANT_PRODUCT_OPTIONS": "Opciones de producto",
         "OPTION_REQUIRED": "Obligatorio",
-        "SOME_OPTION_IS_REQUIRED_SELECT_ONE_VALUE": "Hay opciones obligatorias, seleccione un valor en ellas para continuar"
+        "SOME_OPTION_IS_REQUIRED_SELECT_ONE_VALUE": "Hay opciones obligatorias, seleccione un valor en ellas para continuar",
+        "LEGAL_TEXTS_LABEL": "Acepto los Términos y Condiciones y la Política de Privacidad",
+        "LEGAL_TEXTS_ERROR_MESSAGE": "Debe aceptar los Términos y Condiciones y la Política de Privacidad",
+        "TERMS_AND_CONDITIONS_BUTTON_LABEL": "Leer Términos y Condiciones",
+        "PRIVACY_POLICY_BUTTON_LABEL": "Leer Política de Privacidad",
+        "TERMS_AND_CONDITIONS_LABEL": "Acepto los Términos y Condiciones",
+        "TERMS_AND_CONDITIONS_ERROR_MESSAGE": "Debe aceptar los Términos y Condiciones",
+        "PRIVACY_POLICY_LABEL": "Acepto la Política de Privacidad",
+        "PRIVACY_POLICY_ERROR_MESSAGE": "Debe aceptar la Política de Privacidad"
     }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -409,6 +409,7 @@
         "TERMS_AND_CONDITIONS_LABEL": "Acepto los Términos y Condiciones",
         "TERMS_AND_CONDITIONS_ERROR_MESSAGE": "Debe aceptar los Términos y Condiciones",
         "PRIVACY_POLICY_LABEL": "Acepto la Política de Privacidad",
-        "PRIVACY_POLICY_ERROR_MESSAGE": "Debe aceptar la Política de Privacidad"
+        "PRIVACY_POLICY_ERROR_MESSAGE": "Debe aceptar la Política de Privacidad",
+        "AGREE": "Acepto"
     }
 }

--- a/src/navigation/components/DrawerContent.js
+++ b/src/navigation/components/DrawerContent.js
@@ -86,10 +86,10 @@ class DrawerContent extends Component {
       this.props.navigation.navigate('AboutNav')
 
     const navigateToTerms = () =>
-      this.props.navigation.navigate('TermsNav')
+      this.props.navigation.navigate('TermsNav', { screen: 'TermsHome', params: { showConfirmationButtons: false }  })
 
     const navigateToPricacy = () =>
-      this.props.navigation.navigate('PrivacyNav')
+      this.props.navigation.navigate('PrivacyNav', { screen: 'PrivacyHome', params: { showConfirmationButtons: false }  })
 
     let phoneNumberText = this.props.phoneNumber
     if (this.props.phoneNumber) {

--- a/src/navigation/home/Privacy.js
+++ b/src/navigation/home/Privacy.js
@@ -1,15 +1,40 @@
 import React, { Component } from 'react'
+import { connect } from 'react-redux'
 import LegalText from '../../components/LegalText'
+import { localeDetector } from '../../i18n'
+import { loadPrivacyPolicy } from '../../redux/App/actions'
 
 class Privacy extends Component {
+
+  componentDidMount() {
+    if (!this.props.loadingPrivacyPolicy && !this.props.privacyPolicyText) {
+      this.props.loadPrivacyPolicy(this.props.language)
+    }
+  }
 
   render() {
     return (
       <LegalText
         type="privacy"
+        loading={ this.props.loadingPrivacyPolicy }
+        text={ this.props.privacyPolicyText }
         showConfirmationButtons={this.props.route.params?.showConfirmationButtons} />
     )
   }
 }
 
-export default Privacy
+function mapStateToProps(state) {
+  return {
+    language: localeDetector(),
+    loadingPrivacyPolicy: state.app.loadingPrivacyPolicy,
+    privacyPolicyText: state.app.privacyPolicyText,
+  }
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    loadPrivacyPolicy: (lang) => dispatch(loadPrivacyPolicy(lang)),
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Privacy)

--- a/src/navigation/home/Privacy.js
+++ b/src/navigation/home/Privacy.js
@@ -5,7 +5,9 @@ class Privacy extends Component {
 
   render() {
     return (
-      <LegalText type="privacy" />
+      <LegalText
+        type="privacy"
+        showConfirmationButtons={this.props.route.params?.showConfirmationButtons} />
     )
   }
 }

--- a/src/navigation/home/Privacy.js
+++ b/src/navigation/home/Privacy.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import LegalText from '../../components/LegalText'
 import { localeDetector } from '../../i18n'
-import { loadPrivacyPolicy } from '../../redux/App/actions'
+import { acceptPrivacyPolicy, loadPrivacyPolicy } from '../../redux/App/actions'
 
 class Privacy extends Component {
 
@@ -18,7 +18,8 @@ class Privacy extends Component {
         type="privacy"
         loading={ this.props.loadingPrivacyPolicy }
         text={ this.props.privacyPolicyText }
-        showConfirmationButtons={this.props.route.params?.showConfirmationButtons} />
+        showConfirmationButtons={this.props.route.params?.showConfirmationButtons}
+        dispatchAccept={ (accepted) => this.props.acceptPrivacyPolicy(accepted) } />
     )
   }
 }
@@ -34,6 +35,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return {
     loadPrivacyPolicy: (lang) => dispatch(loadPrivacyPolicy(lang)),
+    acceptPrivacyPolicy: (accepted) => dispatch(acceptPrivacyPolicy(accepted)),
   }
 }
 

--- a/src/navigation/home/Terms.js
+++ b/src/navigation/home/Terms.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import LegalText from '../../components/LegalText'
 import { localeDetector } from '../../i18n'
-import { loadTermsAndConditions } from '../../redux/App/actions'
+import { acceptTermsAndConditions, loadTermsAndConditions } from '../../redux/App/actions'
 
 class Terms extends Component {
 
@@ -18,7 +18,8 @@ class Terms extends Component {
         type="terms"
         loading={ this.props.loadingTerms }
         text={ this.props.termsAndConditionsText }
-        showConfirmationButtons={ this.props.route.params?.showConfirmationButtons } />
+        showConfirmationButtons={ this.props.route.params?.showConfirmationButtons }
+        dispatchAccept={ (accepted) => this.props.acceptTermsAndConditions(accepted) } />
     )
   }
 }
@@ -34,6 +35,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return {
     loadTermsAndConditions: (lang) => dispatch(loadTermsAndConditions(lang)),
+    acceptTermsAndConditions: (accepted) => dispatch(acceptTermsAndConditions(accepted)),
   }
 }
 

--- a/src/navigation/home/Terms.js
+++ b/src/navigation/home/Terms.js
@@ -1,15 +1,40 @@
 import React, { Component } from 'react'
+import { connect } from 'react-redux'
 import LegalText from '../../components/LegalText'
+import { localeDetector } from '../../i18n'
+import { loadTermsAndConditions } from '../../redux/App/actions'
 
 class Terms extends Component {
+
+  componentDidMount() {
+    if (!this.props.loadingTerms && !this.props.termsAndConditionsText) {
+      this.props.loadTermsAndConditions(this.props.language)
+    }
+  }
 
   render() {
     return (
       <LegalText
         type="terms"
-        showConfirmationButtons={this.props.route.params?.showConfirmationButtons} />
+        loading={ this.props.loadingTerms }
+        text={ this.props.termsAndConditionsText }
+        showConfirmationButtons={ this.props.route.params?.showConfirmationButtons } />
     )
   }
 }
 
-export default Terms
+function mapStateToProps(state) {
+  return {
+    language: localeDetector(),
+    loadingTerms: state.app.loadingTerms,
+    termsAndConditionsText: state.app.termsAndConditionsText,
+  }
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    loadTermsAndConditions: (lang) => dispatch(loadTermsAndConditions(lang)),
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Terms)

--- a/src/navigation/home/Terms.js
+++ b/src/navigation/home/Terms.js
@@ -5,7 +5,9 @@ class Terms extends Component {
 
   render() {
     return (
-      <LegalText type="terms" />
+      <LegalText
+        type="terms"
+        showConfirmationButtons={this.props.route.params?.showConfirmationButtons} />
     )
   }
 }

--- a/src/navigation/navigators/DrawerNavigator.js
+++ b/src/navigation/navigators/DrawerNavigator.js
@@ -21,6 +21,7 @@ import Terms from '../home/Terms'
 import Privacy from '../home/Privacy'
 import AccountRegisterConfirm from '../account/RegisterConfirm'
 import AccountResetPasswordNewPassword from '../account/ResetPasswordNewPassword'
+import { HeaderBackButton } from '@react-navigation/elements'
 
 const RegisterConfirmStack = createStackNavigator()
 
@@ -82,7 +83,7 @@ const TermsNavigator = () => (
       component={ Terms }
       options={({ navigation }) => ({
         title: i18n.t('TERMS_OF_SERVICE'),
-        headerLeft: headerLeft(navigation),
+        headerLeft: (props) => <HeaderBackButton { ...props } onPress={ () => navigation.goBack() } />,
       })}
     />
   </TermsStack.Navigator>
@@ -98,7 +99,7 @@ const PrivacyNavigator = () => (
       component={ Privacy }
       options={({ navigation }) => ({
         title: i18n.t('PRIVACY'),
-        headerLeft: headerLeft(navigation),
+        headerLeft: (props) => <HeaderBackButton { ...props } onPress={ () => navigation.goBack() } />,
       })}
     />
   </PrivacyStack.Navigator>

--- a/src/redux/App/actions.js
+++ b/src/redux/App/actions.js
@@ -67,6 +67,14 @@ export const ONBOARDED = '@app/ONBOARDED'
 export const ACCEPT_TERMS_AND_CONDITIONS = '@app/ACCEPT_TERMS_AND_CONDITIONS'
 export const ACCEPT_PRIVACY_POLICY = '@app/ACCEPT_PRIVACY_POLICY'
 
+export const LOAD_TERMS_AND_CONDITIONS_REQUEST = '@app/LOAD_TERMS_AND_CONDITIONS_REQUEST'
+export const LOAD_TERMS_AND_CONDITIONS_SUCCESS = '@app/LOAD_TERMS_AND_CONDITIONS_SUCCESS'
+export const LOAD_TERMS_AND_CONDITIONS_FAILURE = '@app/LOAD_TERMS_AND_CONDITIONS_FAILURE'
+
+export const LOAD_PRIVACY_POLICY_REQUEST = '@app/LOAD_PRIVACY_POLICY_REQUEST'
+export const LOAD_PRIVACY_POLICY_SUCCESS = '@app/LOAD_PRIVACY_POLICY_SUCCESS'
+export const LOAD_PRIVACY_POLICY_FAILURE = '@app/LOAD_PRIVACY_POLICY_FAILURE'
+
 /*
  * Action Creators
  */
@@ -120,6 +128,14 @@ export const onboarded = createAction(ONBOARDED)
 
 export const acceptTermsAndConditions = createAction(ACCEPT_TERMS_AND_CONDITIONS)
 export const acceptPrivacyPolicy = createAction(ACCEPT_PRIVACY_POLICY)
+
+const loadTermsAndConditionsRequest = createAction(LOAD_TERMS_AND_CONDITIONS_REQUEST)
+const loadTermsAndConditionsSuccess = createAction(LOAD_TERMS_AND_CONDITIONS_SUCCESS)
+const loadTermsAndConditionsFailure = createAction(LOAD_TERMS_AND_CONDITIONS_FAILURE)
+
+const loadPrivacyPolicyRequest = createAction(LOAD_PRIVACY_POLICY_REQUEST)
+const loadPrivacyPolicySuccess = createAction(LOAD_PRIVACY_POLICY_SUCCESS)
+const loadPrivacyPolicyFailure = createAction(LOAD_PRIVACY_POLICY_FAILURE)
 
 const registrationErrors = createAction(REGISTRATION_ERRORS)
 
@@ -663,6 +679,44 @@ export function googleSignIn(idToken, navigate = true) {
 
         dispatch(authenticationFailure(message))
 
+      })
+  }
+}
+
+export function loadTermsAndConditions(lang) {
+
+  return (dispatch, getState) => {
+    const { app } = getState()
+    const { httpClient } = app
+
+    dispatch(loadTermsAndConditionsRequest())
+
+    httpClient.get(`/${lang}/terms-text`)
+      .then((res) => {
+        dispatch(loadTermsAndConditionsSuccess(res.text))
+      })
+      .catch(_ => {
+        const message = i18n.t('TRY_LATER')
+        dispatch(loadTermsAndConditionsFailure(message))
+      })
+  }
+}
+
+export function loadPrivacyPolicy(lang) {
+
+  return (dispatch, getState) => {
+    const { app } = getState()
+    const { httpClient } = app
+
+    dispatch(loadPrivacyPolicyRequest())
+
+    httpClient.get(`/${lang}/privacy-text`)
+      .then((res) => {
+        dispatch(loadPrivacyPolicySuccess(res.text))
+      })
+      .catch(_ => {
+        const message = i18n.t('TRY_LATER')
+        dispatch(loadPrivacyPolicyFailure(message))
       })
   }
 }

--- a/src/redux/App/actions.js
+++ b/src/redux/App/actions.js
@@ -64,6 +64,9 @@ export const CLOSE_MODAL = '@app/CLOSE_MODAL'
 export const RESET_MODAL = '@app/RESET_MODAL'
 export const ONBOARDED = '@app/ONBOARDED'
 
+export const ACCEPT_TERMS_AND_CONDITIONS = '@app/ACCEPT_TERMS_AND_CONDITIONS'
+export const ACCEPT_PRIVACY_POLICY = '@app/ACCEPT_PRIVACY_POLICY'
+
 /*
  * Action Creators
  */
@@ -114,6 +117,9 @@ export const setModal = createAction(SET_MODAL)
 export const resetModal = createAction(RESET_MODAL)
 export const closeModal = createAction(CLOSE_MODAL)
 export const onboarded = createAction(ONBOARDED)
+
+export const acceptTermsAndConditions = createAction(ACCEPT_TERMS_AND_CONDITIONS)
+export const acceptPrivacyPolicy = createAction(ACCEPT_PRIVACY_POLICY)
 
 const registrationErrors = createAction(REGISTRATION_ERRORS)
 

--- a/src/redux/App/reducers.js
+++ b/src/redux/App/reducers.js
@@ -13,6 +13,12 @@ import {
   CLEAR_SELECT_SERVER_ERROR,
   CLOSE_MODAL,
   DELETE_PUSH_NOTIFICATION_TOKEN_SUCCESS,
+  LOAD_PRIVACY_POLICY_FAILURE,
+  LOAD_PRIVACY_POLICY_REQUEST,
+  LOAD_PRIVACY_POLICY_SUCCESS,
+  LOAD_TERMS_AND_CONDITIONS_FAILURE,
+  LOAD_TERMS_AND_CONDITIONS_REQUEST,
+  LOAD_TERMS_AND_CONDITIONS_SUCCESS,
   LOGOUT_SUCCESS,
   ONBOARDED,
   PUSH_NOTIFICATION,
@@ -78,6 +84,10 @@ const initialState = {
   },
   termsAndConditionsAccepted: false,
   privacyPolicyAccepted: false,
+  loadingTerms: false,
+  loadingPrivacyPolicy: false,
+  termsAndConditionsText: '',
+  privacyPolicyText: '',
 }
 
 export default (state = initialState, action = {}) => {
@@ -315,6 +325,44 @@ export default (state = initialState, action = {}) => {
       return {
         ...state,
         privacyPolicyAccepted: action.payload,
+      }
+
+    case LOAD_PRIVACY_POLICY_REQUEST:
+      return {
+        ...state,
+        loadingPrivacyPolicy: true,
+      }
+
+    case LOAD_PRIVACY_POLICY_SUCCESS:
+      return {
+        ...state,
+        privacyPolicyText: action.payload,
+        loadingPrivacyPolicy: false,
+      }
+
+    case LOAD_PRIVACY_POLICY_FAILURE:
+      return {
+        ...state,
+        loadingPrivacyPolicy: false,
+      }
+
+    case LOAD_TERMS_AND_CONDITIONS_REQUEST:
+      return {
+        ...state,
+        loadingTerms: true,
+      }
+
+    case LOAD_TERMS_AND_CONDITIONS_SUCCESS:
+      return {
+        ...state,
+        termsAndConditionsText: action.payload,
+        loadingTerms: false,
+      }
+
+    case LOAD_TERMS_AND_CONDITIONS_FAILURE:
+      return {
+        ...state,
+        loadingTerms: false,
       }
   }
 

--- a/src/redux/App/reducers.js
+++ b/src/redux/App/reducers.js
@@ -4,6 +4,7 @@
  */
 import { CONNECTED, DISCONNECTED } from '../middlewares/CentrifugoMiddleware'
 import {
+  ACCEPT_PRIVACY_POLICY, ACCEPT_TERMS_AND_CONDITIONS,
   AUTHENTICATION_FAILURE,
   AUTHENTICATION_REQUEST,
   AUTHENTICATION_SUCCESS,
@@ -75,6 +76,8 @@ const initialState = {
     content: null,
     type: 'default',
   },
+  termsAndConditionsAccepted: false,
+  privacyPolicyAccepted: false,
 }
 
 export default (state = initialState, action = {}) => {
@@ -300,6 +303,18 @@ export default (state = initialState, action = {}) => {
       return {
         ...state,
         firstRun: false,
+      }
+
+    case ACCEPT_TERMS_AND_CONDITIONS:
+      return {
+        ...state,
+        termsAndConditionsAccepted: action.payload,
+      }
+
+    case ACCEPT_PRIVACY_POLICY:
+      return {
+        ...state,
+        privacyPolicyAccepted: action.payload,
       }
   }
 


### PR DESCRIPTION
Closes #1429 

Now, when registering, customers are asked to explicitly accept T&C & privacy policy.
By configuring an env we'll show one or two checkboxes, and when we show two checkboxes when user checks one of them we automatically open its legal text and user has to explicitly accept it.

**One checkbox**
https://user-images.githubusercontent.com/4819244/190481802-5e05d0dd-ee5a-4e54-b550-12c838a687bb.mp4

**Two checkboxes**
https://user-images.githubusercontent.com/4819244/190482353-b49aa52b-9fcd-41e4-a5c9-378f05892ac2.mp4

