### PR TITLE
Ask for a new login when cart has an empty customer

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -485,6 +485,7 @@
         "CHECKOUT_LOOPEAT_ADD_CREDITS": "Credit my wallet",
         "RESTAURANT_LOOPEAT_DISCLAIMER": "Change the number of containers used to pack the order",
         "ZERO_WASTE": "Zero waste",
-        "RESTAURANT_LOOPEAT_UPDATE_FORMATS": "Update packagings"
+        "RESTAURANT_LOOPEAT_UPDATE_FORMATS": "Update packagings",
+        "SESSION_ERROR_TRY_AGAIN": "An error occurred with the session, please login and try again."
     }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -426,6 +426,7 @@
         "SELECT_SAVED_CARD": "Seleccionar una tarjeta de crédito guardada",
         "SAVE_CARD": "Guardar tarjeta de crédito",
         "SEARCH_TAB": "Buscar",
-        "COMPLETE_TASKS": "Completar tareas"
+        "COMPLETE_TASKS": "Completar tareas",
+        "SESSION_ERROR_TRY_AGAIN": "Ocurrió un error con la sesión, por favor inicie sesión nuevamente y vuelva a intentarlo."
     }
 }

--- a/src/navigation/checkout/MoreInfos.js
+++ b/src/navigation/checkout/MoreInfos.js
@@ -56,7 +56,7 @@ class MoreInfos extends Component {
       }
     }
 
-    if (this.props.user.isGuest()) {
+    if (this._userIsGuest()) {
       return this.props.assignCustomer({ email: values.email, telephone })
         .then(() => {
           this._updateCart(payload)
@@ -82,7 +82,7 @@ class MoreInfos extends Component {
       }
     }
 
-    if (!this.props.isAuthenticated && this.props.user.isGuest()) {
+    if (!this.props.isAuthenticated && this._userIsGuest()) {
       if (validate.single(values.email, { presence: true, email: true })) {
         errors.email = this.props.t('INVALID_EMAIL')
       }
@@ -91,8 +91,12 @@ class MoreInfos extends Component {
     return errors
   }
 
+  _userIsGuest() {
+    return this.props.user && this.props.user.isGuest()
+  }
+
   componentDidMount() {
-    if (!this.props.user.isGuest()) {
+    if (!this._userIsGuest()) {
       InteractionManager.runAfterInteractions(() => {
         this.props.assignCustomer({})
       })
@@ -131,7 +135,7 @@ class MoreInfos extends Component {
             </HStack>
             <VStack p="2" style={{ flexShrink: 1 }}>
               <ScrollView>
-                {!this.props.isAuthenticated && this.props.user.isGuest() &&
+                {!this.props.isAuthenticated && this._userIsGuest() &&
                 <FormControl mb="2">
                     <FormControl.Label>Email</FormControl.Label>
                     <Input

--- a/src/redux/Checkout/actions.js
+++ b/src/redux/Checkout/actions.js
@@ -9,7 +9,7 @@ import {selectBillingEmail, selectCartWithHours, selectCartFulfillmentMethod, se
 import {selectIsAuthenticated} from '../App/selectors'
 import {loadAddressesSuccess, setNewOrder, updateOrderSuccess} from '../Account/actions'
 import {isFree} from '../../utils/order'
-import {setLoading, setModal} from '../App/actions';
+import { _logoutSuccess, logoutRequest, setLoading, setModal } from '../App/actions';
 import Share from 'react-native-share';
 import i18next from 'i18next';
 
@@ -1018,19 +1018,25 @@ export function assignCustomer({ email, telephone }, cartContainer = null) {
           dispatch(updateCustomerGuest({ email, telephone }))
         }
         if (!validateCart(res)) {
-          NavigationHolder.dispatch(CommonActions.navigate({
-            name: 'Cart',
-          }))
           dispatch(setModal({
             show: true,
             skippable: true,
-            content: 'An error occurred, please try again later',
+            content: i18next.t('SESSION_ERROR_TRY_AGAIN'),
             type: 'error',
           }))
-          return dispatch(checkoutFailure())
+          dispatch(logoutRequest())
+          user.logout()
+            .then(() => {
+              dispatch(_logoutSuccess())
+            })
+          NavigationHolder.dispatch(CommonActions.navigate({
+            name: 'CheckoutLogin',
+          }))
+          dispatch(checkoutFailure())
+        } else {
+          dispatch(updateCartSuccess(res))
+          dispatch(checkoutSuccess())
         }
-        dispatch(updateCartSuccess(res))
-        dispatch(checkoutSuccess())
       })
       .catch(e => dispatch(checkoutFailure(e)))
   }


### PR DESCRIPTION
This is a patch fix for [empty customer bug](https://github.com/coopcycle/coopcycle-web/issues/3688).

With these changes we don't allow that users can continue with a cart and create an order with an empty customer, which finally ends with [this error](https://coopcycle.sentry.io/issues/3566293937/events/?project=5294179) in the server.

The main issue with this is related to a corrupted or expired session token in the app. In logs we can see a lot of requests with a 401 response but for some reason that we don't understand yet the http client (Axios) doesn't intercept and never ask for a new token to the server.
And this is also related to a mix of tokens in the app, because when the `/assign` endpoint is called for some reason in `auth` header and in `x-coopcycle-session` header we are sending the same token.

This situation makes that the `/assign` endpoint doesn't finally attach a customer to the order and then when user try to pay the order is when we are facing [the error mentioned above](https://coopcycle.sentry.io/issues/3566293937/events/?project=5294179).

With this "patch", we try to identify when the `/assign` endpoint is not able to attach a customer to a cart and in that moment we show a message to the user and then require a new login to renew the session and continue the purchase with a reliable token.

This is how it works:

https://github.com/coopcycle/coopcycle-app/assets/4819244/b5727971-464a-4afc-ade6-2be1a60b1888


