### PR TITLE
feat: `OrderTracking` now parse new `events` key on orders

### DIFF
--- a/src/navigation/checkout/OrderTracking.js
+++ b/src/navigation/checkout/OrderTracking.js
@@ -18,12 +18,15 @@ function stateToStep(events) {
   let index = 0
   let error = 0
 
+  const eventType = [
+    'order:created', 'order:accepted', 'order:refused', 'order:picked',
+    'order:cancelled', 'order:fulfilled',
+  ]
+
   // Normalize events
-  events = events.filter((event) => [ 'order:accepted', 'order:picked', 'order:fulfilled',
-      'order:refused', 'order:cancelled', 'order:created' ].includes(event.type))
-  if (events.length > 0 && events[0].type !== 'order:created') {
-    events.reverse()
-  }
+  events = events.filter((event) => eventType.includes(event.type)).sort((a, b) => {
+    return eventType.indexOf(a.type) - eventType.indexOf(b.type)
+  })
 
   events.forEach(event => {
     switch (event.type) {
@@ -104,7 +107,6 @@ class OrderTrackingPage extends Component {
   ]
 
     const step = stateToStep(order.events)
-    return <ScrollView
     return <ScrollView
       refreshControl={
         <RefreshControl

--- a/src/navigation/checkout/__tests__/OrderTracking.test.js
+++ b/src/navigation/checkout/__tests__/OrderTracking.test.js
@@ -1,0 +1,20 @@
+import { orderToStep } from '../OrderTracking'
+
+describe('OrderTracking', () => {
+  it('should parse based on state', () => {
+    expect(orderToStep({ state: 'accepted' })).toEqual({ error: 0, index: 1 })
+    expect(orderToStep({ state: 'refused' })).toEqual({ error: 1, index: 1 })
+    expect(orderToStep({ state: 'cancelled' })).toEqual({ error: 2, index: 2 })
+  })
+
+  it('should parse based on events', () => {
+    expect(orderToStep({ events: [
+      { type: 'order:accepted' }
+    ] })).toEqual({ error: 0, index: 1 })
+
+    expect(orderToStep({ events: [
+      { type: 'order:accepted' },
+      { type: 'order:picked' }
+    ] })).toEqual({ error: 0, index: 2 })
+  })
+})


### PR DESCRIPTION
Depends on: coopcycle/coopcycle-web#3774