### PR TITLE
Alert riders about address instructions

### DIFF
--- a/src/components/TasksMapView.js
+++ b/src/components/TasksMapView.js
@@ -169,7 +169,7 @@ class TasksMapView extends Component {
   _getWarnings(task) {
     const warnings = []
 
-    if (task.comments && task.comments.length) {
+    if (task.address && task.address.description) {
       warnings.push('comments')
     }
 

--- a/src/navigation/restaurant/components/OrderList.js
+++ b/src/navigation/restaurant/components/OrderList.js
@@ -4,6 +4,7 @@ import { HStack, Icon, Text } from 'native-base'
 import moment from 'moment'
 import { withTranslation } from 'react-i18next'
 import Ionicons from 'react-native-vector-icons/Ionicons'
+import FontAwesome from 'react-native-vector-icons/FontAwesome'
 
 import { formatPrice } from '../../../utils/formatting'
 import OrderNumber from '../../../components/OrderNumber'
@@ -40,6 +41,7 @@ class OrderList extends Component {
           </View>
           <OrderFulfillmentMethodIcon order={ order } small />
           <PaymentMethodInfo fullDetail={false} paymentMethod={order.paymentMethod} />
+          { order.notes ? <Icon as={FontAwesome} name="comments" size="xs"/> : null }
         </HStack>
         <Text>{ `${formatPrice(order.itemsTotal)}` }</Text>
         <Text>{ moment.parseZone(order.pickupExpectedAt).format('LT') }</Text>

--- a/src/navigation/task/components/Details.js
+++ b/src/navigation/task/components/Details.js
@@ -74,17 +74,17 @@ const Details = ({ task, t }) => {
     })
   }
 
-  if (task.comments) {
-    items.push({
-      iconName: 'chatbubbles',
-      text: task.comments,
-    })
-  }
-
   if (task.address.description) {
     items.push({
       iconName: 'information-circle',
       text: task.address.description,
+    })
+  }
+
+  if (task.comments) {
+    items.push({
+      iconName: 'chatbubbles',
+      text: task.comments,
     })
   }
 


### PR DESCRIPTION
Show red alert icon in tasks map view only when the address associated with the task has a description/instruction that riders must read.

And added a comments icon at restaurants order list to alert them about existing comments from customers.