### PR TITLE
CoopCycle does not get alerted to some orders that are created in Stripe

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -935,42 +935,42 @@ PODS:
     - SentryPrivate (= 8.11.0)
   - SentryPrivate (8.11.0)
   - SocketRocket (0.6.1)
-  - Stripe (23.16.0):
-    - StripeApplePay (= 23.16.0)
-    - StripeCore (= 23.16.0)
-    - StripePayments (= 23.16.0)
-    - StripePaymentsUI (= 23.16.0)
-    - StripeUICore (= 23.16.0)
-  - stripe-react-native (0.33.0):
+  - Stripe (23.18.2):
+    - StripeApplePay (= 23.18.2)
+    - StripeCore (= 23.18.2)
+    - StripePayments (= 23.18.2)
+    - StripePaymentsUI (= 23.18.2)
+    - StripeUICore (= 23.18.2)
+  - stripe-react-native (0.35.0):
     - React-Core
-    - Stripe (~> 23.16.0)
-    - StripeApplePay (~> 23.16.0)
-    - StripeFinancialConnections (~> 23.16.0)
-    - StripePayments (~> 23.16.0)
-    - StripePaymentSheet (~> 23.16.0)
-    - StripePaymentsUI (~> 23.16.0)
-  - StripeApplePay (23.16.0):
-    - StripeCore (= 23.16.0)
-  - StripeCore (23.16.0)
-  - StripeFinancialConnections (23.16.0):
-    - StripeCore (= 23.16.0)
-    - StripeUICore (= 23.16.0)
-  - StripePayments (23.16.0):
-    - StripeCore (= 23.16.0)
-    - StripePayments/Stripe3DS2 (= 23.16.0)
-  - StripePayments/Stripe3DS2 (23.16.0):
-    - StripeCore (= 23.16.0)
-  - StripePaymentSheet (23.16.0):
-    - StripeApplePay (= 23.16.0)
-    - StripeCore (= 23.16.0)
-    - StripePayments (= 23.16.0)
-    - StripePaymentsUI (= 23.16.0)
-  - StripePaymentsUI (23.16.0):
-    - StripeCore (= 23.16.0)
-    - StripePayments (= 23.16.0)
-    - StripeUICore (= 23.16.0)
-  - StripeUICore (23.16.0):
-    - StripeCore (= 23.16.0)
+    - Stripe (~> 23.18.0)
+    - StripeApplePay (~> 23.18.0)
+    - StripeFinancialConnections (~> 23.18.0)
+    - StripePayments (~> 23.18.0)
+    - StripePaymentSheet (~> 23.18.0)
+    - StripePaymentsUI (~> 23.18.0)
+  - StripeApplePay (23.18.2):
+    - StripeCore (= 23.18.2)
+  - StripeCore (23.18.2)
+  - StripeFinancialConnections (23.18.2):
+    - StripeCore (= 23.18.2)
+    - StripeUICore (= 23.18.2)
+  - StripePayments (23.18.2):
+    - StripeCore (= 23.18.2)
+    - StripePayments/Stripe3DS2 (= 23.18.2)
+  - StripePayments/Stripe3DS2 (23.18.2):
+    - StripeCore (= 23.18.2)
+  - StripePaymentSheet (23.18.2):
+    - StripeApplePay (= 23.18.2)
+    - StripeCore (= 23.18.2)
+    - StripePayments (= 23.18.2)
+    - StripePaymentsUI (= 23.18.2)
+  - StripePaymentsUI (23.18.2):
+    - StripeCore (= 23.18.2)
+    - StripePayments (= 23.18.2)
+    - StripeUICore (= 23.18.2)
+  - StripeUICore (23.18.2):
+    - StripeCore (= 23.18.2)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -1453,15 +1453,15 @@ SPEC CHECKSUMS:
   Sentry: 39d57e691e311bdb73bc1ab5bbebbd6bc890050d
   SentryPrivate: 48712023cdfd523735c2edb6b06bedf26c4730a3
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  Stripe: fcab417424a45d995aa1e62a39bc942233b61ba3
-  stripe-react-native: fb59ade94b226d967c0473346985ee04a976e078
-  StripeApplePay: 81de266a964b3ad02fb25e8b22fd8c235d2916a8
-  StripeCore: ac141047bca25f5ae945a1cbdd00a90b0d08c616
-  StripeFinancialConnections: d7a452e4bed1195d8978ee4f6c0ba2f82c89fdf4
-  StripePayments: 5804cb9b02cca488042e5cf8cf57a86a5080006b
-  StripePaymentSheet: 06ea6bbf49be869769c46bf31be4fbc3e23b5b19
-  StripePaymentsUI: 24a0349ae8c7e8c7402086703720fe06c52ddea0
-  StripeUICore: ce85e040a22bf0335061d14973d37757528b3d2d
+  Stripe: 85f24cabe407c5b88aabc24287b1e57f03688189
+  stripe-react-native: 2e2dad1734c1c2b71564b66bae4395bfd8419af4
+  StripeApplePay: c94e56e7193815ea0feb67976de9777e78666b87
+  StripeCore: 075589c1503304559dd467c04b816f85207e7789
+  StripeFinancialConnections: e9025e0f6789bac60633e8a61a2e73ea8457fbe2
+  StripePayments: bd848d5787f0fca9ba33c57c3bb108ba08c8c882
+  StripePaymentSheet: 35b361fccabdb99f39a0ada8633cd7a3f8a961fb
+  StripePaymentsUI: 595f6581a9a039fa2f23f9a77235af44c15171fc
+  StripeUICore: 5099399e52853370736aca81b27fc0e86b1822c8
   Yoga: 86fed2e4d425ee4c6eab3813ba1791101ee153c6
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@react-navigation/stack": "^6.3.20",
     "@reduxjs/toolkit": "^1.9.6",
     "@sentry/react-native": "^5.10.0",
-    "@stripe/stripe-react-native": "^0.33.0",
+    "@stripe/stripe-react-native": "^0.35.0",
     "@turf/turf": "^6.5.0",
     "abortcontroller-polyfill": "^1.7.5",
     "axios": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4216,10 +4216,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@stripe/stripe-react-native@^0.33.0":
-  version "0.33.0"
-  resolved "https://registry.yarnpkg.com/@stripe/stripe-react-native/-/stripe-react-native-0.33.0.tgz#665cb096ef0262b801df357309ec5138f49eb665"
-  integrity sha512-UXoRzJ4joiE42HwyWPxaJF3w3lggtfTts9Wi2lthLEmbvS7RdmMrEGNxDRmtBYsF8A3UhAd868L8xDQKyvBfSg==
+"@stripe/stripe-react-native@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@stripe/stripe-react-native/-/stripe-react-native-0.35.0.tgz#4cd159297d22ef5a18cfe7dcb75b36eb205d4681"
+  integrity sha512-bD36NIQVnkUSkjwE7mJoqkb5E4gMBSxnZegkO0gGbgekFqdyZSHghSL6qnRVXPBTr2tRthoNL+FtmVeeYPxVLQ==
 
 "@styled-system/background@^5.1.2":
   version "5.1.2"


### PR DESCRIPTION
Patches: https://github.com/coopcycle/coopcycle-web/issues/3688

I have not been able to reproduce this issue, but there could be cases when the order will be paid on Stripe but will not be moved to the 'new' status on the backend.

This PR includes:

-     updated stripe library
-     cleanup/refactoring to minimise the number of cases when this issue could occur
-     logs to Sentry possible unhappy paths, so if this issue occurs again (hopefully not), there is more information for debugging