### PR TITLE
clean: assign linked tasks when assigning single task

### DIFF
--- a/src/redux/Dispatch/actions.js
+++ b/src/redux/Dispatch/actions.js
@@ -312,8 +312,12 @@ export function assignTask(task, username) {
         username,
         tasks: linkedTasks.map(t => t['@id']),
       })
-        .then((responses) => dispatch(bulkAssignmentTasksSuccess(responses)))
-        .catch(e => dispatch(bulkAssignmentTasksFailure(e)))
+        .then((res) => {
+          dispatch(bulkAssignmentTasksSuccess(res['hydra:member']))
+        })
+        .catch(e => {
+          dispatch(bulkAssignmentTasksFailure(e))
+        })
     } else {
       dispatch(assignTaskRequest())
 
@@ -336,7 +340,7 @@ export function bulkAssignmentTasks(tasks, username) {
       username,
       tasks: tasks.map(t => t['@id']),
     })
-      .then((responses) => dispatch(bulkAssignmentTasksSuccess(responses)))
+      .then((res) => dispatch(bulkAssignmentTasksSuccess(res['hydra:member'])))
       .catch(e => dispatch(bulkAssignmentTasksFailure(e)))
   }
 }

--- a/src/redux/Dispatch/actions.js
+++ b/src/redux/Dispatch/actions.js
@@ -11,6 +11,8 @@ import {
   createTaskListRequest,
   createTaskListSuccess,
 
+  selectAllTasks,
+
   selectSelectedDate,
 } from '../../coopcycle-frontend-js/logistics/redux'
 
@@ -21,6 +23,7 @@ import {
 } from '../Courier';
 
 import { isSameDate } from './utils';
+import { withLinkedTasks } from '../../shared/src/logistics/redux/taskUtils'
 
 /*
  * Action Types
@@ -300,11 +303,24 @@ export function assignTask(task, username) {
 
     const httpClient = getState().app.httpClient
 
-    dispatch(assignTaskRequest())
+    const linkedTasks = withLinkedTasks(task, selectAllTasks(getState()))
 
-    return httpClient.put(`${task['@id']}/assign`, { username })
-      .then(res => dispatch(assignTaskSuccess(res)))
-      .catch(e => dispatch(assignTaskFailure(e)))
+    if (linkedTasks.length > 1) {
+      dispatch(bulkAssignmentTasksRequest())
+
+      return httpClient.put('/api/tasks/assign', {
+        username,
+        tasks: linkedTasks.map(t => t['@id']),
+      })
+        .then((responses) => dispatch(bulkAssignmentTasksSuccess(responses)))
+        .catch(e => dispatch(bulkAssignmentTasksFailure(e)))
+    } else {
+      dispatch(assignTaskRequest())
+
+      return httpClient.put(`${task['@id']}/assign`, { username })
+        .then(res => dispatch(assignTaskSuccess(res)))
+        .catch(e => dispatch(assignTaskFailure(e)))
+    }
   }
 }
 

--- a/src/shared/src/logistics/redux/taskUtils.js
+++ b/src/shared/src/logistics/redux/taskUtils.js
@@ -43,6 +43,24 @@ export function groupLinkedTasks(tasks) {
   })
 }
 
+export function withLinkedTasks(task, allTasks) {
+
+  const groups = groupLinkedTasks(allTasks)
+  const newTasks = []
+
+  if (Object.prototype.hasOwnProperty.call(groups, task['@id']) ) {
+    groups[task['@id']].forEach(taskId => {
+      const t = _.find(allTasks, t => t['@id'] === taskId)
+      newTasks.push(t)
+    })
+  } else {
+    // task with no linked tasks
+    newTasks.push(task)
+  }
+
+ return newTasks
+}
+
 export function mapToColor(tasks) {
   return mapValues(groupLinkedTasks(tasks), taskIds => colorHash.hex(taskIds.join(' ')))
 }


### PR DESCRIPTION
Because of tours + expected behavior to be able to move linked tasks separately I removed the backend code that was (un)assigning automatically linked tasks together

thus it broke the expected behavior in the app dispatch which is : when you assign a single linked task to a rider it assigns also linked tasks

this is the fix