### PR TITLE
For riders and dispatchers, show <order number>-<delivery_position> instead of <task.id>

### DIFF
--- a/src/components/TaskTitle.js
+++ b/src/components/TaskTitle.js
@@ -4,12 +4,23 @@ import { useTranslation } from 'react-i18next';
 const TaskTitle = ({ task }) => {
   const { t } = useTranslation();
 
+  // fallback when task is not defined, not sure if it can happen
+  if (!task) {
+    return <>{t('TASK')}</>
+  }
+
   return (
     <React.Fragment>
-      {t('TASK_WITH_ID', { id: task.id })}
-      {task.metadata &&
-        task.metadata.order_number &&
-        ' | ' + t('ORDER_NUMBER', { number: task.metadata.order_number })}
+      { task.metadata?.order_number ?
+        <>
+          {
+            task.metadata?.delivery_position ?
+            <>{t('ORDER_NUMBER', { number: task.metadata.order_number })}-{task.metadata.delivery_position}</>
+            : <>{t('ORDER_NUMBER', { number: task.metadata.order_number })}</>
+          }
+        </>
+        : <>{t('TASK_WITH_ID', { id: task.id })}</>
+      }
     </React.Fragment>
   );
 };

--- a/src/components/TaskTitle.js
+++ b/src/components/TaskTitle.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { DatadogLogger } from '../Datadog';
 
 const TaskTitle = ({ task }) => {
   const { t } = useTranslation();
 
   // fallback when task is not defined, not sure if it can happen
   if (!task) {
+    DatadogLogger.warning('Task props in TaskTitle is not defined')
     return <>{t('TASK')}</>
   }
 

--- a/src/navigation/navigators/TaskNavigator.js
+++ b/src/navigation/navigators/TaskNavigator.js
@@ -7,13 +7,14 @@ import i18n from '../../i18n';
 import { stackNavigatorScreenOptions } from '../styles';
 
 import ProofOfDeliveryTabs from './TaskAttachmentsNavigator';
+import TaskTitle from '../../components/TaskTitle';
 
 const CompleteStack = createStackNavigator();
 
 const completeTitle = routeParams => {
   if (routeParams) {
     if (routeParams.task) {
-      return `${i18n.t('TASK')} #${routeParams.task.id}`;
+      return <TaskTitle task={routeParams.task} />
     }
     if (routeParams.tasks) {
       return i18n.t('COMPLETE_TASKS');
@@ -52,7 +53,7 @@ export default () => (
       name="TaskHome"
       component={screens.TaskHome}
       options={({ route }) => ({
-        title: `${i18n.t('TASK')} #${route.params?.task.id}`,
+        title: <TaskTitle task={route.params?.task} />
       })}
     />
     <RootStack.Screen

--- a/src/navigation/task/Complete.js
+++ b/src/navigation/task/Complete.js
@@ -283,9 +283,11 @@ class CompleteTask extends Component {
   }
 
   multipleTasksLabel(tasks) {
+
     return tasks.reduce(
       (label, task, idx) => {
-        return `${label}${idx !== 0 ? ',' : ''} #${task.id}`;
+        const taskIdentifier = task?.metadata?.order_number ? `${task.metadata.order_number}-${task?.metadata?.delivery_position}` : task.id
+        return `${label}${idx !== 0 ? ',' : ''} #${taskIdentifier}`;
       },
       `${this.props.t('COMPLETE_TASKS')}: `,
     );

--- a/src/navigation/task/components/Nav.js
+++ b/src/navigation/task/components/Nav.js
@@ -7,6 +7,7 @@ import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import FontAwesome from 'react-native-vector-icons/FontAwesome';
 
 import { navigateToTask } from '../../../navigation/utils';
+import TaskTitle from '../../../components/TaskTitle';
 
 const NavButton = ({ disabled, left, right, onPress, t, task }) => {
   const buttonStyle = [styles.button];
@@ -31,7 +32,7 @@ const NavButton = ({ disabled, left, right, onPress, t, task }) => {
     <TouchableOpacity style={buttonStyle} {...buttonProps}>
       {!disabled && task && right && (
         <Text style={{ marginRight: 10, fontSize: 14 }}>
-          {t('TASK_WITH_ID', { id: task.id })}
+          <TaskTitle task={task} />
         </Text>
       )}
       <Icon
@@ -41,7 +42,7 @@ const NavButton = ({ disabled, left, right, onPress, t, task }) => {
       />
       {!disabled && task && left && (
         <Text style={{ marginLeft: 10, fontSize: 14 }}>
-          {t('TASK_WITH_ID', { id: task.id })}
+          <TaskTitle task={task} />
         </Text>
       )}
     </TouchableOpacity>

--- a/src/redux/Courier/taskEntityReducer.js
+++ b/src/redux/Courier/taskEntityReducer.js
@@ -5,6 +5,7 @@ import {
   ASSIGN_TASK_SUCCESS,
   BULK_ASSIGNMENT_TASKS_SUCCESS,
   UNASSIGN_TASK_SUCCESS,
+  UPDATE_TASK_SUCCESS,
 } from '../Dispatch/actions';
 import { CENTRIFUGO_MESSAGE } from '../middlewares/CentrifugoMiddleware';
 import {
@@ -150,6 +151,7 @@ export const tasksEntityReducer = (
     case START_TASK_SUCCESS:
     case MARK_TASK_DONE_SUCCESS:
     case MARK_TASK_FAILED_SUCCESS:
+    case UPDATE_TASK_SUCCESS:
       return {
         ...state,
         isFetching: false,

--- a/src/redux/Dispatch/actions.js
+++ b/src/redux/Dispatch/actions.js
@@ -380,8 +380,7 @@ export function unassignTask(task, username) {
 export function updateTask(action, task) {
   return function (dispatch, getState) {
     let date = selectSelectedDate(getState());
-    console.log(action)
-    console.log(task)
+
     if (isSameDate(task, date)) {
       switch (action) {
         case 'task:created':

--- a/src/redux/Dispatch/actions.js
+++ b/src/redux/Dispatch/actions.js
@@ -54,6 +54,8 @@ export const ASSIGN_TASK_REQUEST = 'ASSIGN_TASK_REQUEST';
 export const ASSIGN_TASK_SUCCESS = 'ASSIGN_TASK_SUCCESS';
 export const ASSIGN_TASK_FAILURE = 'ASSIGN_TASK_FAILURE';
 
+export const UPDATE_TASK_SUCCESS = 'UPDATE_TASK_SUCCESS';
+
 export const BULK_ASSIGNMENT_TASKS_REQUEST = 'BULK_ASSIGNMENT_TASKS_REQUEST';
 export const BULK_ASSIGNMENT_TASKS_SUCCESS = 'BULK_ASSIGNMENT_TASKS_SUCCESS';
 export const BULK_ASSIGNMENT_TASKS_FAILURE = 'BULK_ASSIGNMENT_TASKS_FAILURE';
@@ -97,6 +99,8 @@ export const cancelTaskFailure = createAction(CANCEL_TASK_FAILURE);
 export const assignTaskRequest = createAction(ASSIGN_TASK_REQUEST);
 export const assignTaskSuccess = createAction(ASSIGN_TASK_SUCCESS);
 export const assignTaskFailure = createAction(ASSIGN_TASK_FAILURE);
+
+export const updateTaskSuccess = createAction(UPDATE_TASK_SUCCESS);
 
 export const bulkAssignmentTasksRequest = createAction(
   BULK_ASSIGNMENT_TASKS_REQUEST,
@@ -397,6 +401,9 @@ export function updateTask(action, task) {
           break;
         case 'task:done':
           dispatch(markTaskDoneSuccess(task));
+          break;
+        case 'task:updated':
+          dispatch(updateTaskSuccess(task));
           break;
         case 'task:failed':
           dispatch(markTaskFailedSuccess(task));

--- a/src/redux/logistics/taskEntityReducers.js
+++ b/src/redux/logistics/taskEntityReducers.js
@@ -11,6 +11,7 @@ import {
   LOAD_TASK_LISTS_SUCCESS,
   LOAD_UNASSIGNED_TASKS_SUCCESS,
   UNASSIGN_TASK_SUCCESS,
+  UPDATE_TASK_SUCCESS,
 } from '../Dispatch/actions';
 
 import {
@@ -31,6 +32,7 @@ export default (state = initialState, action) => {
       let assignedTasks = taskListUtils.assignedTasks(action.payload);
       return taskAdapter.upsertMany(state, assignedTasks);
     }
+    case UPDATE_TASK_SUCCESS:
     case CREATE_TASK_SUCCESS:
     case CANCEL_TASK_SUCCESS:
     case ASSIGN_TASK_SUCCESS:

--- a/src/redux/middlewares/CentrifugoMiddleware/actions.js
+++ b/src/redux/middlewares/CentrifugoMiddleware/actions.js
@@ -27,6 +27,7 @@ export function message(payload) {
         case 'task:started':
         case 'task:done':
         case 'task:failed':
+        case 'task:updated':
           dispatch(updateTask(name, data.task));
           break;
         default:


### PR DESCRIPTION
Related to [https://github.com/coopcycle/coopcycle-web/pull/4583](https://github.com/coopcycle/coopcycle-web/pull/4583)

I think it can be merged safely without merging the related backend PR, but you will see more things if it is set!