### PR TITLE
fix(incidents): remove all code link with the feature flag

### DIFF
--- a/src/navigation/home/FeatureFlags.js
+++ b/src/navigation/home/FeatureFlags.js
@@ -3,17 +3,14 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import {
-  setIncidentEnabled,
   setSpinnerDelayEnabled,
 } from '../../redux/App/actions';
 import {
-  selectIsIncidentEnabled,
   selectIsSpinnerDelayEnabled,
 } from '../../redux/App/selectors';
 
 export default function FeatureFlags() {
   const isSpinnerDelayEnabled = useSelector(selectIsSpinnerDelayEnabled);
-  const isIncidentEnabled = useSelector(selectIsIncidentEnabled);
 
   const { t } = useTranslation();
 
@@ -27,13 +24,6 @@ export default function FeatureFlags() {
         onChange={checked => dispatch(setSpinnerDelayEnabled(checked))}
         defaultIsChecked={isSpinnerDelayEnabled}>
         {t('FEATURE_FLAG_SPINNER_DELAY')}
-      </Checkbox>
-      <Checkbox
-        accessibilityLabel="configure incident"
-        onChange={checked => dispatch(setIncidentEnabled(checked))}
-        defaultIsChecked={isIncidentEnabled}
-        value="incident">
-        {t('FEATURE_FLAG_ENABLE_INCIDENT')}
       </Checkbox>
     </Column>
   );

--- a/src/navigation/task/Complete.js
+++ b/src/navigation/task/Complete.js
@@ -322,9 +322,7 @@ class CompleteTask extends Component {
       : this.props.t('REPORT_INCIDENT');
     const onPress = success
       ? this.markTaskDone.bind(this)
-      : this.props.isIncidentEnabled
-        ? this.reportIncident.bind(this)
-        : this.markTaskFailed.bind(this);
+      : this.reportIncident.bind(this);
 
     const contactName = this.resolveContactName();
 
@@ -400,7 +398,7 @@ class CompleteTask extends Component {
                     totalLines={2}
                     onChangeText={text => this.setState({ notes: text })}
                   />
-                  {!success && this.props.isIncidentEnabled && (
+                  {!success && (
                     <FormControl p="3">
                       <Button
                         bg={
@@ -577,7 +575,6 @@ function mapStateToProps(state) {
     taskCompleteError: selectIsTaskCompleteFailure(state),
     signatures: selectSignatures(state),
     pictures: selectPictures(state),
-    isIncidentEnabled: selectIsIncidentEnabled(state),
   };
 }
 

--- a/src/navigation/task/Complete.js
+++ b/src/navigation/task/Complete.js
@@ -39,7 +39,6 @@ import {
   deletePictureAt,
   deleteSignatureAt,
   markTaskDone,
-  markTaskFailed,
   markTasksDone,
   selectIsTaskCompleteFailure,
   selectPictures,
@@ -187,26 +186,6 @@ class CompleteTask extends Component {
         this.state.contactName,
       );
     }
-  }
-
-  markTaskFailed() {
-    const task = this.props.route.params?.task;
-    const { notes, failureReason } = this.state;
-
-    this.props.markTaskFailed(
-      task,
-      notes,
-      failureReason,
-      () => {
-        // Make sure to use merge = true, so that it doesn't break
-        // when navigating to DispatchTaskList
-        this.props.navigation.navigate({
-          name: this.props.route.params?.navigateAfter,
-          merge: true,
-        });
-      },
-      this.state.contactName,
-    );
   }
 
   reportIncident() {
@@ -580,10 +559,6 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    markTaskFailed: (task, notes, reason, onSuccess, contactName) =>
-      dispatch(
-        markTaskFailed(task, notes, reason, onSuccess, contactName),
-      ),
     markTaskDone: (task, notes, onSuccess, contactName) =>
       dispatch(markTaskDone(task, notes, onSuccess, contactName)),
     markTasksDone: (tasks, notes, onSuccess, contactName) =>

--- a/src/redux/App/actions.js
+++ b/src/redux/App/actions.js
@@ -108,8 +108,6 @@ export const LOAD_PRIVACY_POLICY_REQUEST = '@app/LOAD_PRIVACY_POLICY_REQUEST';
 export const LOAD_PRIVACY_POLICY_SUCCESS = '@app/LOAD_PRIVACY_POLICY_SUCCESS';
 export const LOAD_PRIVACY_POLICY_FAILURE = '@app/LOAD_PRIVACY_POLICY_FAILURE';
 
-export const SET_INCIDENT_ENABLED = '@app/SET_IS_INCIDENT_ENABLED';
-
 /*
  * Action Creators
  */
@@ -215,7 +213,6 @@ const loginByEmailErrors = createFsAction(LOGIN_BY_EMAIL_ERRORS);
 export const setSpinnerDelayEnabled = createAction(
   '@app/SET_IS_SPINNER_DELAY_ENABLED',
 );
-export const setIncidentEnabled = createFsAction(SET_INCIDENT_ENABLED);
 
 export const startSound = createAction('START_SOUND');
 export const stopSound = createAction('STOP_SOUND');

--- a/src/redux/App/reducers.js
+++ b/src/redux/App/reducers.js
@@ -47,7 +47,6 @@ import {
   SET_BASE_URL,
   SET_CURRENT_ROUTE,
   SET_HTTP_CLIENT,
-  SET_INCIDENT_ENABLED,
   SET_INTERNET_REACHABLE,
   SET_LOADING,
   SET_MODAL,
@@ -110,7 +109,6 @@ const initialState = {
   termsAndConditionsText: '',
   privacyPolicyText: '',
   isSpinnerDelayEnabled: true,
-  isIncidentEnabled: true,
 };
 
 function updateNotifications(state, event, params) {
@@ -451,11 +449,6 @@ export default (state = initialState, action = {}) => {
         isSpinnerDelayEnabled: action.payload,
       };
 
-    case SET_INCIDENT_ENABLED:
-      return {
-        ...state,
-        isIncidentEnabled: action.payload,
-      };
   }
 
   return state;

--- a/src/redux/App/selectors.js
+++ b/src/redux/App/selectors.js
@@ -190,9 +190,6 @@ export const selectIsSpinnerDelayEnabled = createSelector(
   },
 );
 
-export const selectIsIncidentEnabled = state =>
-  state.app.isIncidentEnabled ?? false;
-
 export const selectCurrentRoute = state => state.app.currentRoute;
 
 export const selectNotifications = state => state.app.notifications;

--- a/src/redux/Courier/taskActions.js
+++ b/src/redux/Courier/taskActions.js
@@ -300,7 +300,9 @@ export function reportIncident(
   };
 }
 
-
+/*
+ * @deprecated use reportIncident instead
+ */
 export function markTaskFailed(
   task,
   notes = '',
@@ -309,6 +311,7 @@ export function markTaskFailed(
   contactName = '',
 ) {
   return function (dispatch, getState) {
+    console.warn('markTaskFailed is deprecated, use reportIncident instead');
     dispatch(markTaskFailedRequest(task));
     const httpClient = selectHttpClient(getState());
 

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -122,7 +122,6 @@ const appPersistConfig = {
     'firstRun',
     'resumeCheckoutAfterActivation',
     'isSpinnerDelayEnabled',
-    'isIncidentEnabled',
   ],
   migrate: state => {
     if (!state) {


### PR DESCRIPTION
Remove the feature flag for incidents, now they're enabled by dafault.
`markTaskFailed()` is now deprecated