### PR TITLE
Fix for "As a customer, I am unable to desactivate the "zero waste" option in the cart at checkout"

### DIFF
--- a/src/redux/Checkout/reducers.js
+++ b/src/redux/Checkout/reducers.js
@@ -213,6 +213,9 @@ export default (state = initialState, action = {}) => {
           ...state.carts,
           [action.payload.cart.restaurant]: action.payload,
         },
+        // After a successful checkout, we may ask again to enable zero waste
+        // https://github.com/coopcycle/coopcycle-app/issues/1824
+        shouldAskToEnableReusablePackaging: true
       };
 
     case INIT_CART_FAILURE:

--- a/src/redux/Checkout/reducers.js
+++ b/src/redux/Checkout/reducers.js
@@ -297,10 +297,7 @@ export default (state = initialState, action = {}) => {
       return {
         ...state,
         isFetching: false,
-        errors: [],
-        // After a successful checkout, we may ask again to enable zero waste
-        // https://github.com/coopcycle/coopcycle-app/issues/1824
-        shouldAskToEnableReusablePackaging: true,
+        errors: []
       };
 
     case SHOW_ADDRESS_MODAL:


### PR DESCRIPTION
Actually what happen is :
 - the customer disable zerowaste on the cart
 - the cart is updated
 - the event CHECKOUT_SUCCESS is dispatched
 - `shouldAskToEnableReusablePackaging` opens the modal
 - zero waste is activated again

#1945

the comment says that `shouldAskToEnableReusablePackaging` was used to solve #1824 but i dont reproduce the problem in this issue after removing this line. another problem is maybe the event CHECKOUT_SUCCESS because its name state it should be sent only once but it is sent several times, maybe every time the cart is updated?