### PR TITLE
send app info inside a User-Agent header

### DIFF
--- a/src/utils/headers.js
+++ b/src/utils/headers.js
@@ -1,14 +1,9 @@
 import VersionNumber from 'react-native-version-number';
+import { Platform } from 'react-native';
 
 export function defaultHeaders() {
   return {
-    'X-Application-Version':
-      VersionNumber.bundleIdentifier +
-      '@' +
-      VersionNumber.appVersion +
-      ' (' +
-      VersionNumber.buildVersion +
-      ')',
     'X-CoopCycle-App-Version': VersionNumber.appVersion,
+    'User-Agent': `CoopCycle/${VersionNumber.appVersion} (${Platform.OS}/${Platform.Version}) ${VersionNumber.bundleIdentifier}/${VersionNumber.buildVersion}`,
   };
 }


### PR DESCRIPTION
Added a `User-Agent` header:

[CoopCycle base app version] ([OS/OS version]) [app identifier(official app/custom apps)/build version]

Android:

CoopCycle/2.31.0 (android/34) fr.coopcycle/218

iOS:

CoopCycle/2.31.0 (ios/18.2) org.coopcycle.CoopCycle/151
