### PR TITLE
[PERTE-383] Adjustments for the new dispatch screen

### DIFF
--- a/src/components/TasksMapView.js
+++ b/src/components/TasksMapView.js
@@ -300,7 +300,7 @@ class TasksMapView extends Component {
         {this.state.mapHeight && this.state.mapHeight > 0 ? (
           <ClusteredMapView
             data={data}
-            style={[styles.map, { marginBottom: this.state.marginBottom }]}
+            style={[styles.map, { marginBottom: this.state.marginBottom, flex: 1, minHeight: '100%', widht: '100%' }]}
             width={width}
             height={this.state.mapHeight}
             initialRegion={this.initialRegion}

--- a/src/navigation/dispatch/AllTasks.js
+++ b/src/navigation/dispatch/AllTasks.js
@@ -1,34 +1,27 @@
 import { View } from 'native-base';
-import { useEffect } from "react";
-import { useTranslation } from "react-i18next";
-import { ActivityIndicator, InteractionManager } from "react-native";
-import { useDispatch, useSelector } from "react-redux";
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ActivityIndicator, InteractionManager } from 'react-native';
+import { useDispatch, useSelector } from 'react-redux';
 
-import { initialize } from "../../redux/Dispatch/actions";
-import { selectUnassignedTasksNotCancelled } from "../../redux/Dispatch/selectors";
-import { selectSelectedDate, selectTaskLists } from "../../shared/logistics/redux";
-import GroupedTasks from "./components/GroupedTasks";
-import { useAllTasks } from "./useAllTasks";
-
+import { initialize } from '../../redux/Dispatch/actions';
+import { selectUnassignedTasksNotCancelled } from '../../redux/Dispatch/selectors';
 import {
-  Center,
-  Heading,
-  Text
-} from 'native-base';
-
-import BasicSafeAreaView from '../../components/BasicSafeAreaView';
+  selectSelectedDate,
+  selectTaskLists,
+} from '../../shared/logistics/redux';
+import GroupedTasks from './components/GroupedTasks';
+import { useAllTasks } from './useAllTasks';
+import { Center, Heading, Text } from 'native-base';
+import { UNASSIGNED_TASKS_LIST_ID } from '../../shared/src/constants';
 import {
   darkGreyColor,
-  mediumGreyColor,
   whiteColor
 } from '../../styles/common';
-import { UNASSIGNED_TASKS_LIST_ID } from '../../shared/src/constants';
+import { useBackgroundHighlightColor } from '../../styles/theme';
 import AddButton from './components/AddButton';
 
-export default function AllTasks({
-  navigation,
-  route,
-}) {
+export default function AllTasks({ navigation, route }) {
   const { t } = useTranslation();
 
   const selectedDate = useSelector(selectSelectedDate);
@@ -37,11 +30,8 @@ export default function AllTasks({
 
   const dispatch = useDispatch();
 
-  const {
-    isFetching,
-    isError,
-    refetch
-  } = useAllTasks(selectedDate);
+  const { isFetching, isError, refetch } = useAllTasks(selectedDate);
+  const bgHighlightColor = useBackgroundHighlightColor()
 
   useEffect(() => {
     InteractionManager.runAfterInteractions(() => {
@@ -87,27 +77,25 @@ export default function AllTasks({
       <Center w="95%" h="80%">
         <ActivityIndicator animating={true} size="large" />
       </Center>
-    )
+    );
   }
 
   return (
-    <BasicSafeAreaView>
-        <View style={{ backgroundColor: mediumGreyColor }}>
-          <AddButton
-            testID="dispatchNewDelivery"
-            onPress={() => navigation.navigate('DispatchNewDelivery')}>
-            <Text style={{ fontWeight: '700' }}>
-              {selectedDate.format('ll')}
-            </Text>
-          </AddButton>
-        </View>
-        <GroupedTasks
-            sections={sections}
-            navigation
-            route={route}
-            isFetching={isFetching}
-            refetch={refetch}
-        />
-      </BasicSafeAreaView>
+    <>
+      <View style={{ backgroundColor: bgHighlightColor }}>
+        <AddButton
+          testID="dispatchNewDelivery"
+          onPress={() => navigation.navigate('DispatchNewDelivery')}>
+          <Text style={{ fontWeight: '700' }}>{selectedDate.format('ll')}</Text>
+        </AddButton>
+      </View>
+      <GroupedTasks
+        sections={sections}
+        navigation
+        route={route}
+        isFetching={isFetching}
+        refetch={refetch}
+      />
+    </>
   );
 }

--- a/src/navigation/dispatch/TasksMap.js
+++ b/src/navigation/dispatch/TasksMap.js
@@ -14,11 +14,9 @@ import { mediumGreyColor } from '../../styles/common';
 import { navigateToTask } from '../utils';
 import AddButton from './components/AddButton';
 import { useAllTasks } from './useAllTasks';
+import { useBackgroundHighlightColor } from '../../styles/theme';
 
 const styles = StyleSheet.create({
-  newDeliveryBar: {
-    backgroundColor: mediumGreyColor,
-  },
   newDeliveryBarDate: {
     fontWeight: '700',
   },
@@ -45,6 +43,7 @@ export default function TasksMap({ navigation, route }) {
   const allTaskLists = useSelector(selectTaskLists);
   const defaultCoordinates = useSelector(selectSettingsLatLng);
   const selectedDate = useSelector(selectSelectedDate);
+  const bgHighlightColor = useBackgroundHighlightColor()
 
   const { isFetching } = useAllTasks(selectedDate);
 
@@ -60,7 +59,7 @@ export default function TasksMap({ navigation, route }) {
 
   return (
     <>
-      <View style={styles.newDeliveryBar}>
+      <View style={{backgroundColor: bgHighlightColor}}>
         <AddButton
           testID="dispatchNewDelivery"
           onPress={() => navigation.navigate('DispatchNewDelivery')}>

--- a/src/navigation/dispatch/TasksMap.js
+++ b/src/navigation/dispatch/TasksMap.js
@@ -1,18 +1,19 @@
-import { ActivityIndicator, StyleSheet } from 'react-native';
 import { Text, View } from 'native-base';
 import { useMemo } from 'react';
+import { ActivityIndicator, StyleSheet } from 'react-native';
 import { useSelector } from 'react-redux';
 
+import TasksMapView from '../../components/TasksMapView';
+import { selectSettingsLatLng } from '../../redux/App/selectors';
+import {
+  selectSelectedDate,
+  selectTaskLists,
+} from '../../shared/logistics/redux';
 import { getTaskTaskList } from '../../shared/src/logistics/redux/taskListUtils';
 import { mediumGreyColor } from '../../styles/common';
 import { navigateToTask } from '../utils';
-import { selectSelectedDate, selectTaskLists } from '../../shared/logistics/redux';
-import { selectSettingsLatLng } from '../../redux/App/selectors';
-import { useAllTasks } from './useAllTasks';
 import AddButton from './components/AddButton';
-import BasicSafeAreaView from "../../components/BasicSafeAreaView";
-import TasksMapView from '../../components/TasksMapView';
-
+import { useAllTasks } from './useAllTasks';
 
 const styles = StyleSheet.create({
   newDeliveryBar: {
@@ -40,31 +41,25 @@ const styles = StyleSheet.create({
   },
 });
 
-export default function TasksMap({
-  navigation,
-  route,
-}) {
+export default function TasksMap({ navigation, route }) {
   const allTaskLists = useSelector(selectTaskLists);
   const defaultCoordinates = useSelector(selectSettingsLatLng);
   const selectedDate = useSelector(selectSelectedDate);
 
-  const {
-    isFetching,
-  } = useAllTasks(selectedDate);
+  const { isFetching } = useAllTasks(selectedDate);
 
   const mapCenter = useMemo(() => {
     return defaultCoordinates.split(',').map(parseFloat);
   }, [defaultCoordinates]);
 
-  const navigateToSelectedTask = (task) => {
+  const navigateToSelectedTask = task => {
     const taskList = getTaskTaskList(task, allTaskLists);
     // task is one the the task lists' tasks, so taskList is always defined
-    navigateToTask(navigation, route, task, taskList.items)
-  }
-
+    navigateToTask(navigation, route, task, taskList.items);
+  };
 
   return (
-    <BasicSafeAreaView>
+    <>
       <View style={styles.newDeliveryBar}>
         <AddButton
           testID="dispatchNewDelivery"
@@ -90,6 +85,6 @@ export default function TasksMap({
           </View>
         ) : null}
       </View>
-    </BasicSafeAreaView>
-  )
+    </>
+  );
 }

--- a/src/navigation/dispatch/components/GroupedTasks.js
+++ b/src/navigation/dispatch/components/GroupedTasks.js
@@ -22,6 +22,7 @@ import { UNASSIGNED_TASKS_LIST_ID } from '../../../shared/src/constants';
 import BulkEditTasksFloatingButton from './BulkEditTasksFloatingButton';
 import TaskList from '../../../components/TaskList';
 import useSetTaskListItems from '../../../shared/src/logistics/redux/hooks/useSetTaskListItems';
+import { useBackgroundHighlightColor } from '../../../styles/theme';
 
 export default function GroupedTasks({
   sections,
@@ -33,6 +34,7 @@ export default function GroupedTasks({
   const tasksWithColor = useSelector(selectTasksWithColor);
   const unassignedTasks = useSelector(selectUnassignedTasksNotCancelled);
   const bulkEditTasksFloatingButtonRef = useRef(null);
+  const bgHighlightColor = useBackgroundHighlightColor()
 
   // collapsable
   const [collapsedSections, setCollapsedSections] = useState(new Set());
@@ -166,7 +168,7 @@ export default function GroupedTasks({
         sections={sections}
         stickySectionHeadersEnabled={true}
         renderSectionHeader={({ section }) => (
-          <View style={{ backgroundColor: lightGreyColor }}>
+          <View style={{ backgroundColor: bgHighlightColor }}>
             <TouchableOpacity
               onPress={() => handleToggle(section.title)}
               activeOpacity={0.5}

--- a/src/navigation/navigators/DispatchNavigator.js
+++ b/src/navigation/navigators/DispatchNavigator.js
@@ -1,27 +1,31 @@
-import { Box, Icon } from 'native-base';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { createStackNavigator } from '@react-navigation/stack';
 import { HeaderBackButton } from '@react-navigation/elements';
-import { Keyboard, KeyboardAvoidingView, Platform, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
+import { createStackNavigator } from '@react-navigation/stack';
+import { Box, Icon } from 'native-base';
 import { useEffect, useState } from 'react';
+import { Keyboard, KeyboardAvoidingView, Platform, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import FontAwesome from 'react-native-vector-icons/FontAwesome';
 
-import { createDeliverySuccess } from '../../redux/Store/actions';
-import { DeliveryCallbackProvider } from '../delivery/contexts/DeliveryCallbackContext';
-import { NewDeliveryNavigator } from './NewDeliveryNavigator';
 import { useDispatch } from 'react-redux';
-import { useStackNavigatorScreenOptions } from '../styles';
-import HeaderRightButton from '../dispatch/HeaderRightButton';
+import screens, { headerLeft } from '..';
 import i18n from '../../i18n';
 import NavigationHolder from '../../NavigationHolder';
-import screens, { headerLeft } from '..';
+import { createDeliverySuccess } from '../../redux/Store/actions';
+import { blackColor } from '../../styles/common';
+import { useBackgroundContainerColor, useBaseTextColor } from '../../styles/theme';
+import { DeliveryCallbackProvider } from '../delivery/contexts/DeliveryCallbackContext';
+import HeaderRightButton from '../dispatch/HeaderRightButton';
+import { useStackNavigatorScreenOptions } from '../styles';
+import { NewDeliveryNavigator } from './NewDeliveryNavigator';
 import TaskNavigator from './TaskNavigator';
 
 
 const Tab = createBottomTabNavigator();
 
 function CustomTabBar({ navigation }) {
+  const color = useBaseTextColor();
+  const bgColor = useBackgroundContainerColor()
   const [searchQuery, setSearchQuery] = useState('');
   const [showMapButton, setShowMapButton] = useState(true);
 
@@ -43,14 +47,14 @@ function CustomTabBar({ navigation }) {
   }
 
   return (
-    <View style={customTabBarStyles.tabBarContainer}>
+    <View style={[customTabBarStyles.tabBarContainer, { backgroundColor: bgColor }]}>
       { showMapButton
         ? (
           <TouchableOpacity
             style={customTabBarStyles.tabButton}
             onPress={goToTasksMap}
           >
-            <Icon as={FontAwesome} name="map" />
+            <Icon as={FontAwesome} name="map" style={{ color }} />
           </TouchableOpacity>
         )
         : (
@@ -58,7 +62,7 @@ function CustomTabBar({ navigation }) {
             style={customTabBarStyles.tabButton}
             onPress={goToTasksList}
           >
-            <Icon as={FontAwesome} name="list" />
+            <Icon as={FontAwesome} name="list" style={{ color }} />
           </TouchableOpacity>
         )
       }
@@ -67,13 +71,12 @@ function CustomTabBar({ navigation }) {
           as={FontAwesome}
           name="search"
           size={6}
-          color="#000000"
           style={customTabBarStyles.searchIcon}
         />
         <TextInput
           style={customTabBarStyles.searchInput}
           placeholder="Search"
-          placeholderTextColor="#000000"
+          placeholderTextColor={blackColor}
           value={searchQuery}
           onChangeText={setSearchQuery}
           onSubmitEditing={handleSearchSubmit}
@@ -84,7 +87,7 @@ function CustomTabBar({ navigation }) {
         style={customTabBarStyles.tabButton}
         onPress={() => navigation.navigate('DispatchTasksFilters')}
       >
-        <Icon as={FontAwesome} name="filter" />
+        <Icon as={FontAwesome} name="filter" style={{ color }} />
       </TouchableOpacity>
     </View>
   );
@@ -93,13 +96,11 @@ function CustomTabBar({ navigation }) {
 const customTabBarStyles = StyleSheet.create({
   tabBarContainer: {
     alignItems: 'center',
-    backgroundColor: '#FFFFFF',
-    borderTopColor: '#ddd',
-    borderTopWidth: 1,
     flexDirection: 'row',
-    height: 68,
     justifyContent: 'space-between',
     paddingHorizontal: 10,
+    paddingTop: 10,
+    paddingBottom: 30,
   },
   tabButton: {
     padding: 10,
@@ -118,7 +119,6 @@ const customTabBarStyles = StyleSheet.create({
     marginRight: 8,
   },
   searchInput: {
-    color: '#000000',
     flex: 1,
     fontFamily: 'OpenSans-SemiBold',
     fontSize: 14,
@@ -169,6 +169,7 @@ function Tabs() {
         tabBar={(props) => <CustomTabBar {...props} />}
         screenOptions={{
           headerShown: false,
+          tabBarShowLabel: false,
         }}>
         <Tab.Screen
           name="DispatchAllTasks"

--- a/src/navigation/navigators/DispatchNavigator.js
+++ b/src/navigation/navigators/DispatchNavigator.js
@@ -8,7 +8,7 @@ import FontAwesome from 'react-native-vector-icons/FontAwesome';
 
 import { useDispatch } from 'react-redux';
 import screens, { headerLeft } from '..';
-import HeaderHeightAwareKeyboardAvoidingView from '../../components/HeaderHeightAwareKeyboardAvoidingView';
+import KeyboardAdjustView from '../../components/KeyboardAdjustView';
 import i18n from '../../i18n';
 import NavigationHolder from '../../NavigationHolder';
 import { createDeliverySuccess } from '../../redux/Store/actions';
@@ -100,7 +100,7 @@ const customTabBarStyles = StyleSheet.create({
     justifyContent: 'space-between',
     paddingHorizontal: 10,
     paddingTop: 10,
-    paddingBottom: 30,
+    paddingBottom: 10,
   },
   tabButton: {
     padding: 10,
@@ -132,7 +132,7 @@ const customTabBarStyles = StyleSheet.create({
 function Tabs() {
 
   return (
-    <HeaderHeightAwareKeyboardAvoidingView>
+    <KeyboardAdjustView style={{ flex: 1 }} androidBehavior={'heigh'}>
       <Tab.Navigator
         tabBar={(props) => <CustomTabBar {...props} />}
         screenOptions={{
@@ -156,7 +156,7 @@ function Tabs() {
           })}
         />
       </Tab.Navigator>
-    </HeaderHeightAwareKeyboardAvoidingView>
+    </KeyboardAdjustView>
   );
 };
 

--- a/src/navigation/navigators/DispatchNavigator.js
+++ b/src/navigation/navigators/DispatchNavigator.js
@@ -2,13 +2,13 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { HeaderBackButton } from '@react-navigation/elements';
 import { createStackNavigator } from '@react-navigation/stack';
 import { Box, Icon } from 'native-base';
-import { useEffect, useState } from 'react';
-import { Keyboard, KeyboardAvoidingView, Platform, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useState } from 'react';
+import { StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
 import FontAwesome from 'react-native-vector-icons/FontAwesome';
 
 import { useDispatch } from 'react-redux';
 import screens, { headerLeft } from '..';
+import HeaderHeightAwareKeyboardAvoidingView from '../../components/HeaderHeightAwareKeyboardAvoidingView';
 import i18n from '../../i18n';
 import NavigationHolder from '../../NavigationHolder';
 import { createDeliverySuccess } from '../../redux/Store/actions';
@@ -130,41 +130,9 @@ const customTabBarStyles = StyleSheet.create({
 });
 
 function Tabs() {
-  const [keyboardHeight, setKeyboardHeight] = useState(0);
-  const insets = useSafeAreaInsets();
-
-  useEffect(() => {
-    const keyboardDidShowListener = Keyboard.addListener(
-      'keyboardDidShow',
-      (e) => {
-        const calculated = e.endCoordinates.height - 92;
-        setKeyboardHeight(calculated);
-      }
-    );
-
-    const keyboardDidHideListener = Keyboard.addListener(
-      'keyboardDidHide',
-      () => {
-        setKeyboardHeight(0);
-      }
-    );
-
-    return () => {
-      keyboardDidShowListener.remove();
-      keyboardDidHideListener.remove();
-    };
-  }, [insets.bottom]);
 
   return (
-    <KeyboardAvoidingView
-      behavior={Platform.OS === 'android' ? 'height' : 'padding'}
-      style={{ flex: 1 }}
-      keyboardVerticalOffset={
-        Platform.OS === 'android'
-          ? -keyboardHeight
-          : insets.bottom
-      }
-    >
+    <HeaderHeightAwareKeyboardAvoidingView>
       <Tab.Navigator
         tabBar={(props) => <CustomTabBar {...props} />}
         screenOptions={{
@@ -188,7 +156,7 @@ function Tabs() {
           })}
         />
       </Tab.Navigator>
-    </KeyboardAvoidingView>
+    </HeaderHeightAwareKeyboardAvoidingView>
   );
 };
 

--- a/src/navigation/navigators/DispatchNavigator.js
+++ b/src/navigation/navigators/DispatchNavigator.js
@@ -132,7 +132,7 @@ const customTabBarStyles = StyleSheet.create({
 function Tabs() {
 
   return (
-    <KeyboardAdjustView style={{ flex: 1 }} androidBehavior={'heigh'}>
+    <KeyboardAdjustView style={{ flex: 1 }} androidBehavior="height">
       <Tab.Navigator
         tabBar={(props) => <CustomTabBar {...props} />}
         screenOptions={{


### PR DESCRIPTION
## Issue: [#383](https://github.com/coopcycle/coopcycle/issues/383)

### Tasks:
- [ ] Make the bulk assign button to correctly dis/appear after:
  - Taping and selecting unassign/any courier, if the process (spinner loading) takes several seconds, sometimes the bulk button doesn't dissapear.
  - Collapsing and expanding the sections seems to NOT affect the internal's button state (relates to the task below).
- [ ] When swipping an order, we should also swipe all the related tasks so the user can visually see that is affecting all those tasks.
  - We should not display the bulk assign button in those cases, but only if the user selects another order or a single task for other order.
- [ ] Currently, when collapsing a section, the `TaskList` is not parsed and it causes to lose the swiped state of a task when collapsing and then expanding again.
  - This was done to improve parsing/responsiveness performance, but it's far from ideal.
  - The bulk assign button seems to behave fine anyways (but review and make sure it _really_ works fine).
  - We might revert the change that avoids `TaskList` parsing and that's it for this issue now..!
  - The performance improvement thing will be tacked at [#384](https://github.com/coopcycle/coopcycle/issues/384). 
- [x] The on-screen keyboard when writing in the search text input makes the whole screen to go up, hiding the top bars.
- [ ] Add autocomplete support for "Filter by keywords +" that searches amongst resto/store, couriers and tags.
- [x] Fix the app display in "dark mode".
- [x] Fix the map that explodes in the android emulator.
- [x] Fix the task navigation when inside a task detail (it's broken).
- [ ] Try to fix the e2e test `e2e/dispatch/success__create_delivery.spec.js`
  - It's the same as `e2e/store/success__create_delivery.spec.js` but somehow the dispatch one isn't working.
  - It seems to hang in the dropoff address text input (the text is not entered in the field, it just keeps blank/empty).
  - It seems to work fine locally when runned isolated `(make e2e-android-only TESTFILE=dispatch/success__create_delivery.spec.js)` but it fails at CI.
    - Locally, this warning/error needs to be dismissed quickly because the test is not able to tap the "Next" button otherwise: `Warning: Unknown: Support for defaultProps will be removed from memo components in a future major release. Use JavaScript default parameters instead.`
      - Note that it says "from memo components", there is another similar warning/error with other than "memo" message.
    - If we can get rid of all the "Support for defaultProps will be removed.." the better..!