### PR TITLE
[PERTE-443] Keyboard dispatch screensize calculation

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -154,7 +154,7 @@
       android:name=".MainActivity"
       android:label="@string/app_name"
       android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
-      android:windowSoftInputMode="adjustPan"
+      android:windowSoftInputMode="adjustResize"
       android:exported="true"
       android:launchMode="singleTask">
       <intent-filter>

--- a/src/components/AuthenticateForm.js
+++ b/src/components/AuthenticateForm.js
@@ -82,7 +82,7 @@ const styles = StyleSheet.create({
   },
   spacer: {
     alignItems: 'center',
-    padding: 20,
+    padding: 4,
   },
 });
 

--- a/src/components/KeyboardAdjustView.js
+++ b/src/components/KeyboardAdjustView.js
@@ -15,12 +15,12 @@ import { AvoidSoftInputView } from 'react-native-avoid-softinput';
 export default function KeyboardAdjustView({
   children,
   style,
-  androidBehavior = 'padding', // FIXME: try to avoid using this prop; see the comment below
   testID,
 }) {
-  const [viewHeight, setViewHeight] = useState(0);
 
   const windowDimensions = useWindowDimensions();
+  const [viewHeight, setViewHeight] = useState(0);
+
 
   const onLayout = event => {
     const currentFrame = event.nativeEvent.layout;
@@ -30,37 +30,14 @@ export default function KeyboardAdjustView({
   };
 
   if (Platform.OS === 'android') {
-    // on Android we rely on the OS to put focused text input above the keyboard
-
-    const topOffset = windowDimensions.height - viewHeight; // status bar (~24) + toolbar (~56)
-
-    // extra View is a workaround for this issue: https://github.com/facebook/react-native/issues/35599
-    return (
-      <View style={style} onLayout={onLayout} testID={testID}>
-        <KeyboardAvoidingView
-          style={{ flex: 1 }}
-          keyboardVerticalOffset={topOffset}
-          behavior={androidBehavior}>
+      // AndroidManifest.xml updated to adjustResize to handle keyboard positioning
+      // conflicts with KeyboardAvoidingView eliminated
+      
+      return (
+        <View style={[style, { flex: 1 }]} onLayout={onLayout} testID={testID}>
           {children}
-        </KeyboardAvoidingView>
-      </View>
-    );
-
-    // FIXME:
-    //  we current have both android:windowSoftInputMode="adjustPan" and KeyboardAvoidingView,
-    //  which are conflicting in some situations.
-    //  I propose to switch to android:windowSoftInputMode="adjustResize"
-    //  which is the default one for React Native,
-    //  then we can fully rely on the OS to adjust the view and put the focused text input above the keyboard
-    //  and then we can get rid of KeyboardAvoidingView on Android
-    //  we will need to test all screens that have a text input
-    //  and also apply this fix: https://github.com/react-navigation/react-navigation/issues/10715#issuecomment-1852564585
-
-    // return (
-    //   <View style={style} {...props}>
-    //     {children}
-    //   </View>
-    // )
+        </View>
+      );
   } else if (Platform.OS === 'ios') {
     // on iOS we need to adjust the view and put the focused text input above the keyboard manually
 

--- a/src/navigation/account/AddressDetails.js
+++ b/src/navigation/account/AddressDetails.js
@@ -25,7 +25,7 @@ class AddressDetails extends Component {
     };
 
     return (
-      <KeyboardAdjustView style={{ flex: 1 }} androidBehavior={''}>
+      <KeyboardAdjustView style={{ flex: 1 }}>
         <MapView
           style={{
             height: width * 0.55,

--- a/src/navigation/delivery/NewDeliveryStore.js
+++ b/src/navigation/delivery/NewDeliveryStore.js
@@ -75,7 +75,7 @@ const NewDeliveryStore = (props) => {
 
   // TODO: We should do something about the "KeyboardAdjustView" solution..!
   return (
-    <KeyboardAdjustView style={{ flex: 1 }} androidBehavior={'padding'}>
+    <KeyboardAdjustView style={{ flex: 1 }}>
       <SafeAreaView
         style={{
           flex: 1,

--- a/src/navigation/navigators/DispatchNavigator.js
+++ b/src/navigation/navigators/DispatchNavigator.js
@@ -111,7 +111,7 @@ const customTabBarStyles = StyleSheet.create({
 function Tabs() {
 
   return (
-    <KeyboardAdjustView style={{ flex: 1 }} androidBehavior="height">
+    <KeyboardAdjustView style={{ flex: 1 }}>
       <Tab.Navigator
         tabBar={(props) => <CustomTabBar {...props} />}
         screenOptions={{


### PR DESCRIPTION
## Issue: [#443](https://github.com/coopcycle/coopcycle/issues/443)

Keyboard displays with incorrect height/sizing on first search attempt in dispatch screen on Android (IOS works as expected).

### Related issue: https://github.com/coopcycle/coopcycle-app/issues/1650

### Tasks:
- [x] Fix the thing!