### PR TITLE
[PERTE-491] Put back task status icon

### DIFF
--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -98,7 +98,7 @@ const TaskList = ({
         data={tasks}
         keyExtractor={(item, index) => {
           const tagNames = (item.tags || []).map(t => t.name);
-          return `${item['@id']}-${tagNames.length === 0 ? 'no_tag' : tagNames.join('-')}`;
+          return `${item['@id']}-${item.status}-${tagNames.length === 0 ? 'no_tag' : tagNames.join('-')}`;
         }}
         renderItem={renderItem}
         refreshing={refreshing}

--- a/src/components/TaskListItem.tsx
+++ b/src/components/TaskListItem.tsx
@@ -153,7 +153,7 @@ const TaskTypeIcon = ({ task }) => (
 );
 
 const TaskStatusIcon = ({ task }) => {
-  const color = '#FFFFFF'; // Make it invisible
+  const color = '#000000'; // Make it invisible
   const testID = `taskListItemIcon:${task.status}:${task.id}`;
 
   switch (task.status) {
@@ -188,7 +188,7 @@ const TaskStatusIcon = ({ task }) => {
         />
       );
     default:
-      return <View />;
+      return (<View />);
   }
 };
 
@@ -464,7 +464,6 @@ const TaskListItem = forwardRef(
                     numberOfLines={1}>
                     {taskTitle}
                   </Text>
-                  <TaskStatusIcon task={task} />
                 </HStack>
                 {address && (
                   <Text style={textStyle} numberOfLines={1}>
@@ -474,11 +473,12 @@ const TaskListItem = forwardRef(
                 <Text numberOfLines={1} style={textStyle}>
                   {task.address?.streetAddress}
                 </Text>
-                <HStack alignItems="center">
+                <HStack alignItems="center" justifyContent="space-between">
                   <Text pr="2" style={textStyle}>
                     {moment(task.doneAfter).format('LT')} -{' '}
                     {moment(task.doneBefore).format('LT')}
                   </Text>
+                  <TaskStatusIcon task={task} />
                   {task.address?.description &&
                   task.address?.description.length ? (
                     <Icon mr="2" as={FontAwesome} name="comments" size="xs" />

--- a/src/components/TaskStatusIcon.tsx
+++ b/src/components/TaskStatusIcon.tsx
@@ -27,7 +27,6 @@ export const TaskTypeIcon = ({ task }) => (
 );
 
 export const TaskStatusIcon = ({ task }) => {
-  const color = '#FFFFFF'; // Make it invisible
   const testID = `taskListItemIcon:${task.status}:${task.id}`;
 
   switch (task.status) {
@@ -35,7 +34,6 @@ export const TaskStatusIcon = ({ task }) => {
       return (
         <Icon
           as={FontAwesome}
-          color={color}
           name={doingIconName}
           style={iconStyle(task)}
           testID={testID}
@@ -45,7 +43,6 @@ export const TaskStatusIcon = ({ task }) => {
       return (
         <Icon
           as={FontAwesome}
-          color={color}
           name={doneIconName}
           style={iconStyle(task)}
           testID={testID}
@@ -55,7 +52,6 @@ export const TaskStatusIcon = ({ task }) => {
       return (
         <Icon
           as={FontAwesome}
-          color={color}
           name={failedIconName}
           style={iconStyle(task)}
           testID={testID}


### PR DESCRIPTION
## Issue: [#491](https://github.com/coopcycle/coopcycle/issues/491)

Related issues:
- https://github.com/coopcycle/coopcycle/issues/455
- https://github.com/coopcycle/coopcycle/issues/459

For now, we'll put the icons next to the time range.
The new layout is going to be worked at [#459](https://github.com/coopcycle/coopcycle/issues/459) so the final location is going to be defined in there.

- [x] Make it visible and locate the icons next to the time range as we discussed.
- [x] Make sure it looks good in dark mode.