### PR TITLE
[PERTE-451] Avoid task updated notification modal for admins and dispatchers

### DIFF
--- a/src/redux/App/selectors.ts
+++ b/src/redux/App/selectors.ts
@@ -220,13 +220,15 @@ export const selectNotifications = state => state.app.notifications;
 export const selectNotificationsWithSound = createSelector(
   selectNotifications,
   selectTasksChangedAlertSound,
-  (notifications, tasksChangedAlertSound) =>
+  selectLoggedInUser,
+  (notifications, tasksChangedAlertSound, loggedInUser) =>
     notifications.filter(notification => {
       switch (notification.event) {
         case EVENT_ORDER.CREATED:
           return true;
         case EVENT_TASK_COLLECTION.CHANGED:
-          return tasksChangedAlertSound;
+          // Skip users with dispatcher/admin roles
+          return tasksChangedAlertSound && loggedInUser && !(loggedInUser.hasRole('ROLE_DISPATCHER') || loggedInUser.hasRole('ROLE_ADMIN'));
         default:
           return false;
       }
@@ -236,13 +238,15 @@ export const selectNotificationsWithSound = createSelector(
 export const selectNotificationsToDisplay = createSelector(
   selectNotifications,
   selectAutoAcceptOrdersEnabled,
-  (notifications, autoAcceptOrdersEnabled) =>
+  selectLoggedInUser,
+  (notifications, autoAcceptOrdersEnabled, loggedInUser) =>
     notifications.filter(notification => {
       switch (notification.event) {
         case EVENT_ORDER.CREATED:
           return !autoAcceptOrdersEnabled;
         case EVENT_TASK_COLLECTION.CHANGED:
-          return true;
+          // Skip users with dispatcher/admin roles
+          return loggedInUser && !(loggedInUser.hasRole('ROLE_DISPATCHER') || loggedInUser.hasRole('ROLE_ADMIN'));
         default:
           return true;
       }


### PR DESCRIPTION
## Issue https://github.com/coopcycle/coopcycle/issues/451

Secondary changes were done at coopcycle-web PR:
https://github.com/coopcycle/coopcycle-web/pull/5089

The solution was to not consider as `"selectNotificationsToDisplay"` directly in app, because we still need the notification to update the task/tasklist in the app for every subscribed user (centrifugo / websocket).

### Tasks:
- [x] Filter out task:updated notifications for admins and dispatchers.
- [x] Make sure all test pass!