### PR TITLE
[PERTE-507] Adjustments to the dispatch screen after applying gluestack

### DIFF
--- a/e2e/dispatch/success__assign_unassign_tasks_and_orders.spec.js
+++ b/e2e/dispatch/success__assign_unassign_tasks_and_orders.spec.js
@@ -31,6 +31,9 @@ describeif(device.getPlatform() === 'android')
   });
 
   it('should assign a single task to a courier and then unassign it', async () => {
+    // Show unassigned tasks section
+    //await toggleSectionUnassigned(); (THIS IS A BUG: it should be hidden by default but it's visible)
+
     // All 3 tasks are unassigned
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 0, "Acme (task #1)");
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 1, "Acme (task #2)");
@@ -39,12 +42,16 @@ describeif(device.getPlatform() === 'android')
     // Assign task #2
     await assignTaskToUser(USER_JANE, 1);
 
+    // Show unassigned tasks section (THIS IS A BUG: it hides once we assign the order above)
+    await toggleSectionUnassigned(); // TODO: Remove this line once the bug is fixed
     // Verify task #1 and #3 were not assigned
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 0, "Acme (task #1)");
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 1, "Acme (task #3)");
 
     // Hide unassigned tasks section
     await toggleSectionUnassigned();
+    // Show USER_JANE's tasks section
+    await toggleSectionUser(USER_JANE);
 
     // Verify task #2 is on USER_JANE's task list
     await expectTaskTitleToHaveText(`${USER_JANE}TasksList`, 0, "Acme (task #2)");
@@ -62,6 +69,9 @@ describeif(device.getPlatform() === 'android')
   });
 
   it('should assign a single order (with 3 tasks) to a courier and then unassign it', async () => {
+    // Show unassigned tasks section
+    //await toggleSectionUnassigned(); (THIS IS A BUG: it should be hidden by default but it's visible)
+
     // All 4 tasks are unassigned
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 0, "Acme (task #1)");
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 1, "Acme (task #2)");
@@ -71,11 +81,15 @@ describeif(device.getPlatform() === 'android')
     // Assign order #1 (that has 3 tasks) from task #2
     await assignOrderToUser(USER_JANE, 1);
 
+    // Show unassigned tasks section (THIS IS A BUG: it hides once we assign the order above)
+    await toggleSectionUnassigned(); // TODO: Remove this line once the bug is fixed
     // Verify that now the 1st unassigned task is #5
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 0, "Acme (task #5)");
 
     // Hide unassigned tasks section
     await toggleSectionUnassigned();
+    // Show USER_JANE's tasks section
+    await toggleSectionUser(USER_JANE);
 
     // Verify all the 3 tasks are on USER_JANE's task list
     await expectTaskTitleToHaveText(`${USER_JANE}TasksList`, 0, "Acme (task #1)");
@@ -96,6 +110,9 @@ describeif(device.getPlatform() === 'android')
   });
 
   it('should bulk assign two tasks to a courier and then unassign them', async () => {
+    // Show unassigned tasks section
+    //await toggleSectionUnassigned(); (THIS IS A BUG: it should be hidden by default but it's visible)
+
     // All 3 tasks are unassigned
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 0, "Acme (task #1)");
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 1, "Acme (task #2)");
@@ -106,12 +123,16 @@ describeif(device.getPlatform() === 'android')
     await swipeLeftTask(UNASSIGNED_TASKS_LIST_ID, 2);
     await bulkAssignToUser(USER_JANE);
 
+    // Show unassigned tasks section (THIS IS A BUG: it hides once we assign the order above)
+    await toggleSectionUnassigned(); // TODO: Remove this line once the bug is fixed
     // Verify that now the 1st unassigned task is #2 and then #5
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 0, "Acme (task #2)");
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 1, "Acme (task #5)");
 
     // Hide unassigned tasks section
     await toggleSectionUnassigned();
+    // Show USER_JANE's tasks section
+    await toggleSectionUser(USER_JANE);
 
     // Verify the 2 tasks are on USER_JANE's task list
     await expectTaskTitleToHaveText(`${USER_JANE}TasksList`, 0, "Acme (task #1)");
@@ -132,6 +153,9 @@ describeif(device.getPlatform() === 'android')
   });
 
   it('should bulk assign a task and an order to a courier and then unassign them', async () => {
+    // Show unassigned tasks section
+    //await toggleSectionUnassigned(); (THIS IS A BUG: it should be hidden by default but it's visible)
+
     // All 4 tasks are unassigned
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 0, "Acme (task #1)");
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 1, "Acme (task #2)");
@@ -143,11 +167,15 @@ describeif(device.getPlatform() === 'android')
     await swipeLeftTask(UNASSIGNED_TASKS_LIST_ID, 3);
     await bulkAssignToUser(USER_JANE);
 
+    // Show unassigned tasks section (THIS IS A BUG: it hides once we assign the order above)
+    await toggleSectionUnassigned(); // TODO: Remove this line once the bug is fixed
     // Verify that now the 1st unassigned task is #7
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 0, "Acme (task #7)");
 
     // Hide unassigned tasks section
     await toggleSectionUnassigned();
+    // Show USER_JANE's tasks section
+    await toggleSectionUser(USER_JANE);
 
     // Verify all the 4 tasks are on USER_JANE's task list
     await expectTaskTitleToHaveText(`${USER_JANE}TasksList`, 0, "Acme (task #1)");
@@ -171,6 +199,9 @@ describeif(device.getPlatform() === 'android')
   });
 
   it('should bulk assign a task and an order to a courier and then reassign them to another courier and then unassign them all again', async () => {
+    // Show unassigned tasks section
+    //await toggleSectionUnassigned(); (THIS IS A BUG: it should be hidden by default but it's visible)
+
     // All 5 tasks are unassigned
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 0, "Acme (task #1)");
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 1, "Acme (task #2)");
@@ -184,6 +215,8 @@ describeif(device.getPlatform() === 'android')
     await swipeLeftTask(UNASSIGNED_TASKS_LIST_ID, 3);
     await bulkAssignToUser(USER_JANE);
 
+    // Show unassigned tasks section (THIS IS A BUG: it hides once we assign the order above)
+    await toggleSectionUnassigned(); // TODO: Remove this line once the bug is fixed
     // Verify that now the 1st unassigned task is #7 and then #9
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 0, "Acme (task #7)");
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 1, "Acme (task #9)");
@@ -193,6 +226,8 @@ describeif(device.getPlatform() === 'android')
 
     // Hide unassigned tasks section
     await toggleSectionUnassigned();
+    // Show USER_JANE's tasks section
+    await toggleSectionUser(USER_JANE);
 
     // Verify all the 4 tasks are on USER_JANE's task list
     await expectTaskTitleToHaveText(`${USER_JANE}TasksList`, 0, "Acme (task #1)");
@@ -214,6 +249,8 @@ describeif(device.getPlatform() === 'android')
 
     // Hide USER_JANE's tasks section
     await toggleSectionUser(USER_JANE);
+    // Show USER_ZAK's tasks section
+    //await toggleSectionUser(USER_ZAK); (THIS IS A BUG: it should be hidden by default but it's visible)
 
     // Verify all the 5 tasks are on USER_ZAK's task list
     await expectTaskTitleToHaveText(`${USER_ZAK}TasksList`, 0, "Acme (task #7)");

--- a/e2e/dispatch/success__create_delivery.spec.js
+++ b/e2e/dispatch/success__create_delivery.spec.js
@@ -2,7 +2,7 @@ import {
   describeif,
   //selectAutocompleteAddress,
   tapById,
-  //typeTextQuick,
+  typeTextQuick,
   waitToBeVisible,
 } from "../support/commands";
 import {
@@ -34,6 +34,8 @@ const typeTextQuickJustForThisTest = async (elemId, text) => {
   return await element(by.id(elemId)).typeText(text);
 };
 
+const CONTACT_NAME = 'Alice';
+
 //FIXME: Run these tests for iOS too (see https://github.com/coopcycle/coopcycle-ops/issues/97)
 describeif(device.getPlatform() === 'android')
   ('Dispatch - Create delivery', () => {
@@ -44,6 +46,9 @@ describeif(device.getPlatform() === 'android')
   });
 
   it('should create a delivery for a store', async () => {
+    // Show unassigned tasks section
+    //await toggleSectionUnassigned(); (THIS IS A BUG: it should be hidden by default but it's visible)
+
     await tapById('dispatchNewDelivery');
 
     // Select store
@@ -60,7 +65,7 @@ describeif(device.getPlatform() === 'android')
     // Append "\n" to make sure virtual keyboard is hidden after entry
     // https://github.com/wix/detox/issues/209
     await waitToBeVisible('delivery__dropoff__contact_name');
-    await typeTextQuickJustForThisTest('delivery__dropoff__contact_name', 'Alice\n');
+    await typeTextQuickJustForThisTest('delivery__dropoff__contact_name', `${CONTACT_NAME}\n`);
 
     await waitToBeVisible('delivery__dropoff__phone');
     await typeTextQuickJustForThisTest('delivery__dropoff__phone', '0612345678\n');
@@ -77,8 +82,12 @@ describeif(device.getPlatform() === 'android')
     // Select default values and continue
     await tapById('delivery__next_button');
 
-    // Check the new task was created
-    await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 6, "Acme (task #11)");
+    // Search by contact name
+    await typeTextQuick('searchTextInput', `${CONTACT_NAME}\n`);
+    await waitToBeVisible('dispatchTasksSearchResults');
+
+    // Check the new tasks were created
+    await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 0, "Acme (task #12)");
   });
 
 });

--- a/e2e/dispatch/success__filter_tasks.spec.js
+++ b/e2e/dispatch/success__filter_tasks.spec.js
@@ -16,6 +16,7 @@ import {
   loadDispatchFixture,
   loginDispatcherUser,
   toggleSectionUnassigned,
+  toggleSectionUser,
 } from './utils';
 
 const USER_JANE = 'jane';
@@ -31,13 +32,21 @@ describeif(device.getPlatform() === 'android')
   });
 
   it('should correctly apply filters to tasks on different tasklists', async () => {
+    // Show unassigned tasks section
+    //await toggleSectionUnassigned(); (THIS IS A BUG: it should be hidden by default but it's visible)
+
     // Assign the 1st order in the list with tasks #1+#2+#3
     await assignOrderToUser(USER_JANE);
+    // Show unassigned tasks section (THIS IS A BUG: it hides once we assign the order above)
+    await toggleSectionUnassigned(); // TODO: Remove this line once the bug is fixed
     // Assign the 1st order in the list with tasks #5+#4
     await assignOrderToUser(USER_ZAK);
 
     // Hide unassigned tasks section
     await toggleSectionUnassigned();
+    // Show USER_JANE's and USER_ZAK's tasks section
+    await toggleSectionUser(USER_JANE);
+    //await toggleSectionUser(USER_ZAK); (THIS IS A BUG: it should be hidden by default but it's visible)
 
     // Verify tasks #1+#2+#3 are on USER_JANE's task list
     await expectTaskTitleToHaveText(`${USER_JANE}TasksList`, 0, "Acme (task #1)");
@@ -169,13 +178,13 @@ describeif(device.getPlatform() === 'android')
     await waitToBeVisible('dispatchTasksFiltersView');
     await tapById('showKeywordsFiltersButton');
     await waitToBeVisible('keywordsFilterView');
-    await typeTextQuick('searchTextInput', 'Task #1\n');
+    await typeTextQuick('searchTextInput', '#1\n');
 
     // Go back
     await tapById('keywordsFilterGoToAllTasksButton');
 
     // Verify tasks were found
-    await toggleSectionUnassigned();
+    //await toggleSectionUnassigned(); (THIS IS A BUG: it should be hidden but it's visible)
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 0, "Acme (task #11)");
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 1, "Acme (task #10)");
 

--- a/e2e/dispatch/success__filter_tasks.spec.js
+++ b/e2e/dispatch/success__filter_tasks.spec.js
@@ -2,6 +2,7 @@ import { UNASSIGNED_TASKS_LIST_ID } from "../../src/shared/src/constants";
 import {
   describeif,
   expectToNotExist,
+  sleep,
   swipeDown,
   swipeRight,
   tapById,
@@ -127,6 +128,7 @@ describeif(device.getPlatform() === 'android')
 
     // Open the map screen
     await tapById('toggleTasksMapListButton');
+    await sleep(5000); // Wait for the map to be fully loaded
 
     // Verify tasks #6+#7 markers are on the map
     await waitToExist('taskmarker-6-0'); // If we don't force the task list update, this marker will be: 'taskmarker-6-5'

--- a/e2e/dispatch/success__search_tasks.spec.js
+++ b/e2e/dispatch/success__search_tasks.spec.js
@@ -10,6 +10,7 @@ import {
   loadDispatchFixture,
   loginDispatcherUser,
   toggleSectionUnassigned,
+  toggleSectionUser,
 } from './utils';
 
 const USER_JANE = 'jane';
@@ -25,13 +26,21 @@ describeif(device.getPlatform() === 'android')
   });
 
   it('should correctly find tasks on different tasklists', async () => {
+    // Show unassigned tasks section
+    //await toggleSectionUnassigned(); (THIS IS A BUG: it should be hidden by default but it's visible)
+
     // Assign the 1st order in the list with tasks #1+#2+#3
     await assignOrderToUser(USER_JANE);
+    // Show unassigned tasks section (THIS IS A BUG: it hides once we assign the order above)
+    await toggleSectionUnassigned(); // TODO: Remove this line once the bug is fixed
     // Assign the 1st order in the list with tasks #5+#4
     await assignOrderToUser(USER_ZAK);
 
     // Hide unassigned tasks section
     await toggleSectionUnassigned();
+    // Show USER_JANE's and USER_ZAK's tasks section
+    await toggleSectionUser(USER_JANE);
+    //await toggleSectionUser(USER_ZAK); (THIS IS A BUG: it should be hidden by default but it's visible)
 
     // Verify tasks #1+#2+#3 are on USER_JANE's task list
     await expectTaskTitleToHaveText(`${USER_JANE}TasksList`, 0, "Acme (task #1)");
@@ -45,6 +54,8 @@ describeif(device.getPlatform() === 'android')
     await typeTextQuick('searchTextInput', `${USER_JANE}\n`);
     await waitToBeVisible('dispatchTasksSearchResults');
 
+    // Show USER_JANE's tasks section on search results
+    await toggleSectionUser(USER_JANE);
     // Verify tasks #1+#2+#3 were found on USER_JANE's task list
     await expectTaskTitleToHaveText(`${USER_JANE}TasksListSearchResults`, 0, "Acme (task #1)");
     await expectTaskTitleToHaveText(`${USER_JANE}TasksListSearchResults`, 1, "Acme (task #2)");
@@ -57,18 +68,29 @@ describeif(device.getPlatform() === 'android')
     await typeTextQuick('searchTextInput', 'Acme\n');
     await waitToBeVisible('dispatchTasksSearchResults');
 
+    // Show unassigned tasks section on search results
+    await toggleSectionUnassigned();
     // Verify tasks were found on different task lists
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 0, "Acme (task #7)");
+    // Hide unassigned and show USER_JANE's tasks section on search results
+    await toggleSectionUnassigned();
+    await toggleSectionUser(USER_JANE);
     await expectTaskTitleToHaveText(`${USER_JANE}TasksListSearchResults`, 0, "Acme (task #1)");
+    // Hide USER_JANE's and show USER_ZAK's tasks section on search results
+    await toggleSectionUser(USER_JANE);
+    await toggleSectionUser(USER_ZAK);
     await expectTaskTitleToHaveText(`${USER_ZAK}TasksListSearchResults`, 0, "Acme (task #5)");
 
     // Go back
     await device.pressBack();
 
     // Search by task title
-    await typeTextQuick('searchTextInput', 'Task #1\n');
+    await typeTextQuick('searchTextInput', '#1\n');
     await waitToBeVisible('dispatchTasksSearchResults');
 
+    // Show unassigned and USER_JANE's tasks section on search results
+    await toggleSectionUnassigned();
+    await toggleSectionUser(USER_JANE);
     // Verify tasks were found on different task lists
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 0, "Acme (task #11)");
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 1, "Acme (task #10)");
@@ -81,6 +103,9 @@ describeif(device.getPlatform() === 'android')
     await typeTextQuick('searchTextInput', 'rue Milton\n');
     await waitToBeVisible('dispatchTasksSearchResults');
 
+    // Show unassigned and USER_JANE's tasks section on search results
+    await toggleSectionUnassigned();
+    await toggleSectionUser(USER_JANE);
     // Verify tasks were found on different task lists
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 0, "Acme (task #11)");
     await expectTaskTitleToHaveText(`${USER_JANE}TasksListSearchResults`, 0, "Acme (task #3)");
@@ -92,6 +117,8 @@ describeif(device.getPlatform() === 'android')
     await typeTextQuick('searchTextInput', 'Maradona\n');
     await waitToBeVisible('dispatchTasksSearchResults');
 
+    // Show unassigned tasks section on search results
+    //await toggleSectionUnassigned(); (THIS IS A BUG: it should be hidden by default but it's visible)
     // Verify task #10 was found on unassigled task list
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 0, "Acme (task #10)");
 
@@ -102,6 +129,9 @@ describeif(device.getPlatform() === 'android')
     await typeTextQuick('searchTextInput', 'Marley\n');
     await waitToBeVisible('dispatchTasksSearchResults');
 
+    // Show unassigned and USER_JANE's tasks section on search results
+    await toggleSectionUnassigned();
+    await toggleSectionUser(USER_JANE);
     // Verify tasks were found on different task lists
     await expectTaskTitleToHaveText(UNASSIGNED_TASKS_LIST_ID, 0, "Acme (task #11)");
     await expectTaskTitleToHaveText(`${USER_JANE}TasksListSearchResults`, 0, "Acme (task #3)");

--- a/e2e/dispatch/success__start_complete_task.spec.js
+++ b/e2e/dispatch/success__start_complete_task.spec.js
@@ -11,6 +11,7 @@ import {
   loadDispatchFixture,
   loginDispatcherUser,
   toggleSectionUnassigned,
+  toggleSectionUser,
 } from './utils';
 
 const USER_JANE = 'jane';
@@ -23,11 +24,16 @@ describeif(device.getPlatform() === 'android')
     await loadDispatchFixture();
     await loginDispatcherUser();
 
+    // Show unassigned tasks section
+    //await toggleSectionUnassigned(); (THIS IS A BUG: it should be hidden by default but it's visible)
+
     // Assign task #1
     await assignTaskToUser(USER_JANE);
 
     // Hide unassigned tasks section
-    await toggleSectionUnassigned();
+    //await toggleSectionUnassigned(); (THIS IS A BUG: it hides once we assign the order above)
+    // Show USER_JANE's tasks section
+    await toggleSectionUser(USER_JANE);
 
     // Open assigned task #1
     await tapById(`${USER_JANE}TasksList:task:0`);
@@ -45,7 +51,6 @@ describeif(device.getPlatform() === 'android')
     // Verify task #1 has status "DOING"
     await waitToBeVisible('taskListItemIcon:DOING:1');
   });
-
 
   it('should mark a task as DONE', async () => {
     // Swipe complete button, tap 'ok' and press 'Complete'

--- a/e2e/store/success__create_delivery.spec.js
+++ b/e2e/store/success__create_delivery.spec.js
@@ -10,6 +10,8 @@ import {
   loginStoreUser,
 } from './utils';
 
+const CONTACT_NAME = 'Alice';
+
 //FIXME: Run these tests for iOS too (see https://github.com/coopcycle/coopcycle-ops/issues/97)
 describeif(device.getPlatform() === 'android')
   ('Store - Create delivery', () => {
@@ -33,7 +35,7 @@ describeif(device.getPlatform() === 'android')
     // Append "\n" to make sure virtual keyboard is hidden after entry
     // https://github.com/wix/detox/issues/209
     await waitToBeVisible('delivery__dropoff__contact_name');
-    await typeTextQuick('delivery__dropoff__contact_name', 'Alice\n');
+    await typeTextQuick('delivery__dropoff__contact_name', `${CONTACT_NAME}\n`);
 
     await waitToBeVisible('delivery__dropoff__phone');
     await typeTextQuick('delivery__dropoff__phone', '0612345678\n');
@@ -51,6 +53,6 @@ describeif(device.getPlatform() === 'android')
     await tapById('delivery__next_button');
 
     // Return to Store screen and validate new delivery is accessible
-    await expect(element(by.text('Alice'))).toBeVisible();
+    await expect(element(by.text(CONTACT_NAME))).toBeVisible();
   });
 });

--- a/src/components/TaskInfo.tsx
+++ b/src/components/TaskInfo.tsx
@@ -34,8 +34,8 @@ export const styles = StyleSheet.create({
     fontWeight: 700,
     textTransform: 'uppercase',
   },
-  // This one is used just for e2e tests purposes
-  invisibleText: __DEV__ ? { fontSize: 10 } : { color: 'transparent', fontSize: 0 },
+  // This one is used just for dev and e2e tests purposes
+  invisibleText: __DEV__ ? { fontSize: 12 } : { color: 'transparent', fontSize: 0 },
   hasIncident: {
     borderColor: yellowColor,
   },
@@ -68,7 +68,7 @@ interface ITaskInfoProps {
 function TaskInfo({ task, isPickup, taskTestId }: ITaskInfoProps) {
   const { t } = useTranslation();
   const orderTasks = useSelector(selectTasksByOrder(getOrderNumber(task)));
-  const taskDropoffTitle = getTaskTitleForOrder(task, t);
+  const taskTitle = getTaskTitleForOrder(task);
   const alignedTextStyle = isPickup
     ? [styles.text, { textAlign: 'right' as const }]
     : [styles.text];
@@ -141,6 +141,9 @@ function TaskInfo({ task, isPickup, taskTestId }: ITaskInfoProps) {
 
         {isPickup ? (
           <HStack space="md">
+            {taskTitle && task.orgName !== taskTitle ? (
+              <Text numberOfLines={1}>{taskTitle}</Text>
+            ) : null}
             <DropoffArrows size="lg" count={getDropoffCount(orderTasks)} />
             <Animated.View
               style={{
@@ -161,13 +164,14 @@ function TaskInfo({ task, isPickup, taskTestId }: ITaskInfoProps) {
               <FAIcon name="level-down-alt" size={18} />
             </Animated.View>
             <Text numberOfLines={1} style={{ flex: 1 }}>
-              {`${getDropoffPosition(task, orderTasks)} ${taskDropoffTitle}`}
+              {getDropoffPosition(task, orderTasks)}
+              {taskTitle && task.orgName !== taskTitle ? ` ${taskTitle}` : null}
             </Text>
           </HStack>
         )}
 
         <Text numberOfLines={1} style={alignedTextStyle}>
-          {task.address?.streetAddress}
+          {task.address.streetAddress}
         </Text>
         <HStack
           className="items-center"

--- a/src/components/TaskMarker.tsx
+++ b/src/components/TaskMarker.tsx
@@ -54,6 +54,7 @@ const getTaskIcon = (task: Task, type?: string) => {
   return taskTypeIcon(task);
 };
 
+// TODO check this use case
 const WARNING_ICON_STYLE: TextStyle = {
   position: 'absolute',
   right: 0,

--- a/src/components/TaskMarker.tsx
+++ b/src/components/TaskMarker.tsx
@@ -1,137 +1,116 @@
 import React from 'react';
+import { TextStyle, View, ViewStyle } from 'react-native';
 import { Icon } from '@/components/ui/icon';
 import { Text } from '@/components/ui/text';
-import { View } from 'react-native';
-import FontAwesome from 'react-native-vector-icons/FontAwesome';
 
 import {
-  taskTypeIcon,
   DoneIcon,
   FailedIcon,
+  taskTypeIcon,
 } from '../navigation/task/styles/common';
-import { darkGreyColor, lightGreyColor, redColor } from '../styles/common';
-import { useBackgroundContainerColor } from '../styles/theme';
+import { redColor } from '../styles/common';
+import {
+  useBackgroundContainerColor,
+  useBlackAndWhiteTextColor,
+  useSecondaryTextColor,
+} from '../styles/theme';
 import { Task } from '../types/task';
 
-const markerColor = (task: Task) => {
-  let color = darkGreyColor;
+const CONTAINER_SIZE = 32;
 
+const getTaskColor = (
+  task: Task,
+  defaultColor: string,
+  unassignedColor: string,
+): string => {
+  if (task.status === 'FAILED') {
+    return redColor;
+  }
+
+  // Use tag color if available (first tag if multiple)
   if (task.tags.length > 0) {
-    color = task.tags[0].color;
-  } else if (!task.isAssigned) {
-    color = lightGreyColor;
+    return task.tags[0].color;
   }
 
-  switch (task.status) {
-    case 'DONE':
-      return color;
-    case 'FAILED':
-      return redColor;
-    default:
-      return color;
-  }
+  // Use unassigned color for unassigned tasks
+  return task.isAssigned ? defaultColor : unassignedColor;
 };
 
-const markerOpacity = (task: Task) => {
-  switch (task.status) {
-    case 'DONE':
-      return 0.4;
-    case 'FAILED':
-      return 0.4;
-    default:
-      return 1;
-  }
+const getTaskOpacity = (task: Task): number => {
+  return ['DONE', 'FAILED'].includes(task.status) ? 0.4 : 1;
 };
 
-const containerSize = 32;
-
-const backgroundStyle = ({
-  task,
-  backgroundColor,
-}: {
-  task: Task;
-  backgroundColor: string;
-}) => {
-  return {
-    width: containerSize,
-    height: containerSize,
-    backgroundColor: backgroundColor,
-    borderColor: markerColor(task),
-    opacity: markerOpacity(task),
-    borderWidth: 2,
-    borderStyle: 'solid',
-    borderTopLeftRadius: containerSize / 2,
-    borderTopRightRadius: containerSize / 2,
-    borderBottomLeftRadius: containerSize / 2,
-    borderBottomRightRadius: 0,
-    transform: [{ rotate: '45deg' }],
-  };
-};
-
-const iconStyle = (task: Task) => {
-  return {
-    position: 'absolute',
-    color: markerColor(task),
-    opacity: markerOpacity(task),
-  };
-};
-
-const taskStatusIcon = (task: Task) => {
-  switch (task.status) {
-    case 'DONE':
-      return DoneIcon;
-    case 'FAILED':
-      return FailedIcon;
-    default:
-      return taskTypeIcon(task);
-  }
-};
-
-const icon = (task: Task, type: string) => {
+const getTaskIcon = (task: Task, type?: string) => {
   if (type === 'status') {
-    return taskStatusIcon(task);
-  } else {
-    return taskTypeIcon(task);
+    switch (task.status) {
+      case 'DONE':
+        return DoneIcon;
+      case 'FAILED':
+        return FailedIcon;
+      default:
+        return taskTypeIcon(task);
+    }
   }
+  return taskTypeIcon(task);
 };
 
-const warnIconStyle = () => {
-  return {
-    position: 'absolute',
-    right: 0,
-    top: -3,
-    color: 'red',
-    fontSize: 38,
-  };
+const WARNING_ICON_STYLE: TextStyle = {
+  position: 'absolute',
+  right: 0,
+  top: -3,
+  color: 'red',
+  fontSize: 38,
 };
 
-interface IProps {
+interface TaskMarkerProps {
   task: Task;
   type?: string;
   hasWarnings?: boolean;
   testID?: string;
 }
-export default ({ task, type, hasWarnings, testID }: IProps) => {
-  const _icon = icon(task, type);
+
+const TaskMarker = ({ task, type, hasWarnings, testID }: TaskMarkerProps) => {
   const backgroundColor = useBackgroundContainerColor();
+  const defaultColor = useBlackAndWhiteTextColor();
+  const unassignedColor = useSecondaryTextColor();
+
+  const taskColor = getTaskColor(task, defaultColor, unassignedColor);
+  const taskOpacity = getTaskOpacity(task);
+  const taskIcon = getTaskIcon(task, type);
+
+  const markerStyle: ViewStyle = {
+    width: CONTAINER_SIZE,
+    height: CONTAINER_SIZE,
+    backgroundColor,
+    borderColor: taskColor,
+    opacity: taskOpacity,
+    borderWidth: 2,
+    borderStyle: 'solid',
+    borderTopLeftRadius: CONTAINER_SIZE / 2,
+    borderTopRightRadius: CONTAINER_SIZE / 2,
+    borderBottomLeftRadius: CONTAINER_SIZE / 2,
+    borderBottomRightRadius: 0,
+    transform: [{ rotate: '45deg' }],
+  };
+
+  const iconStyleObj: TextStyle = {
+    position: 'absolute',
+    color: taskColor,
+    opacity: taskOpacity,
+  };
 
   return (
     <View
       style={{ margin: 10, alignItems: 'center', justifyContent: 'center' }}>
-      <View
-        style={backgroundStyle({ task, backgroundColor })}
-        testID={testID || `taskmarker-${task.id}`}
-      />
-      {hasWarnings ? (
-        <Text bold style={warnIconStyle()}>
+      <View style={markerStyle} testID={testID || `taskmarker-${task.id}`} />
+      {hasWarnings && (
+        <Text bold style={WARNING_ICON_STYLE}>
           .
         </Text>
-      ) : null}
-      <Icon
-        as={_icon}
-        style={iconStyle(task)}
-        size="md"
-      />
+      )}
+      <Icon as={taskIcon} style={iconStyleObj} size="md" />
     </View>
   );
 };
+
+export default TaskMarker;

--- a/src/components/TasksMapView.tsx
+++ b/src/components/TasksMapView.tsx
@@ -19,7 +19,12 @@ import { MessageCircle } from 'lucide-react-native';
 
 import { filterTasks } from '../redux/logistics/utils';
 import { getTaskListTasks } from '../shared/src/logistics/redux/taskListUtils';
-import { greyColor, whiteColor } from '../styles/common';
+import {
+  greyColor,
+  lightGreyColor,
+  redColor,
+  whiteColor,
+} from '../styles/common';
 import { getIcon, isDisplayPaymentMethodInList } from './PaymentMethodInfo';
 import {
   selectIsHideUnassignedFromMap,
@@ -272,11 +277,10 @@ class TasksMapView extends Component {
       return null;
     }
 
-    return taskLists.map((taskList, index) => {
+    return taskLists.map((taskList: TaskList, index: number) => {
       if (taskList.isUnassignedTaskList && this.props.isHideUnassignedFromMap) {
         return null;
       }
-
       const key = `polyline-${taskList.id}-${index}`;
 
       return (
@@ -284,8 +288,12 @@ class TasksMapView extends Component {
           key={key}
           testID={key}
           coordinates={this.getCoordinates(taskList)}
-          strokeWidth={3}
-          strokeColor={taskList.color}
+          strokeWidth={2}
+          strokeColor={
+            taskList.isUnassignedTaskList
+              ? this.props.unassignedPolylineColor || lightGreyColor
+              : taskList.color
+          }
           lineDashPattern={taskList.isUnassignedTaskList ? [20, 10] : undefined}
         />
       );

--- a/src/components/TasksMapView.tsx
+++ b/src/components/TasksMapView.tsx
@@ -20,7 +20,7 @@ import { MessageCircle } from 'lucide-react-native';
 import { filterTasks } from '../redux/logistics/utils';
 import { getTaskListTasks } from '../shared/src/logistics/redux/taskListUtils';
 import { greyColor, whiteColor } from '../styles/common';
-import { isDisplayPaymentMethodInList, getIcon } from './PaymentMethodInfo';
+import { getIcon, isDisplayPaymentMethodInList } from './PaymentMethodInfo';
 import {
   selectIsHideUnassignedFromMap,
   selectIsPolylineOn,
@@ -239,7 +239,7 @@ class TasksMapView extends Component {
         <TaskMarker
           task={task}
           type="status"
-          hasWarnings={warnings.length}
+          hasWarnings={warnings.length > 0}
           testID={key}
         />
         <Callout

--- a/src/navigation/courier/TasksPage.tsx
+++ b/src/navigation/courier/TasksPage.tsx
@@ -12,6 +12,7 @@ import { withTranslation } from 'react-i18next';
 import RNPinScreen from 'react-native-pin-screen';
 
 import { blueColor } from '../../styles/common';
+import { useSecondaryTextColor } from '../../styles/theme';
 import { connectCentrifugo } from '../../redux/middlewares/CentrifugoMiddleware/actions';
 import { createCurrentTaskList } from '../../shared/src/logistics/redux/taskListUtils';
 import { navigateToTask } from '../../navigation/utils';
@@ -52,6 +53,7 @@ function TaskMapPage({ navigation, route }) {
   const selectedDate = useSelector(selectTaskSelectedDate);
   const tasks = useSelector(selectFilteredTasks);
   const latlng = useSelector(selectSettingsLatLng);
+  const unassignedPolylineColor = useSecondaryTextColor();
 
   const courierTaskList = useMemo(() => {
     const taskList = createCurrentTaskList(tasks);
@@ -83,6 +85,7 @@ function TaskMapPage({ navigation, route }) {
         <TasksMapView
           mapCenter={mapCenter}
           taskLists={[courierTaskList]}
+          unassignedPolylineColor={unassignedPolylineColor}
           onMarkerCalloutPress={task =>
             // We use `courierTaskList.items` here so each task has the properties added at `createCurrentTaskList`
             navigateToTask(navigation, route, task, courierTaskList.items)

--- a/src/navigation/delivery/components/TimeSlotSelector.tsx
+++ b/src/navigation/delivery/components/TimeSlotSelector.tsx
@@ -101,7 +101,9 @@ export default function TimeSlotSelector({
                 numberOfLines={1}
                 style={{
                   color:
-                    selectedTimeSlot === timeSlot['@id'] ? 'white' : '#878787',
+                    selectedTimeSlot === timeSlot['@id']
+                      ? backgroundHighlightColor
+                      : '#878787',
                 }}>
                 {timeSlot.name}
               </ButtonText>

--- a/src/navigation/dispatch/TasksMap.tsx
+++ b/src/navigation/dispatch/TasksMap.tsx
@@ -18,7 +18,7 @@ import {
 } from '../../shared/logistics/redux';
 import { selectDispatchUiTaskFilters } from '../../redux/Dispatch/selectors';
 import { useAllTasks } from './useAllTasks';
-import { useBackgroundHighlightColor } from '../../styles/theme';
+import { useBackgroundHighlightColor, useSecondaryTextColor } from '../../styles/theme';
 import AddButton from './components/AddButton';
 import TasksMapView from '../../components/TasksMapView';
 
@@ -53,6 +53,7 @@ export default function TasksMap({ navigation, route }) {
   const defaultCoordinates = useSelector(selectSettingsLatLng);
   const selectedDate = useSelector(selectSelectedDate);
   const bgHighlightColor = useBackgroundHighlightColor();
+  const unassignedPolylineColor = useSecondaryTextColor();
 
   const { isFetching } = useAllTasks(selectedDate);
 
@@ -90,6 +91,7 @@ export default function TasksMap({ navigation, route }) {
         <TasksMapView
           mapCenter={mapCenter}
           taskLists={mergedTaskListsWithUnassigned}
+          unassignedPolylineColor={unassignedPolylineColor}
           onMarkerCalloutPress={navigateToSelectedTask}
           uiFilters={uiFilters}
         />

--- a/src/navigation/dispatch/components/GroupedTasks.tsx
+++ b/src/navigation/dispatch/components/GroupedTasks.tsx
@@ -94,8 +94,24 @@ export default function GroupedTasks({
     ? sections.filter(section => section.tasksCount > 0)
     : sections;
 
-  // collapsable
   const [collapsedSections, setCollapsedSections] = useState(new Set());
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  // Initialize all sections as collapsed only on first load
+  useEffect(() => {
+    if (
+      !isInitialized &&
+      !isFetching &&
+      filteredSections.length > 0 &&
+      taskLists.length > 0
+    ) {
+      const allSectionTitles = new Set(
+        filteredSections.map(section => section.title),
+      );
+      setCollapsedSections(allSectionTitles);
+      setIsInitialized(true);
+    }
+  }, [filteredSections, isInitialized, isFetching, taskLists.length]);
 
   // Update tasks functions
   const {
@@ -302,6 +318,9 @@ export default function GroupedTasks({
 
   const renderItem = useCallback(
     ({ section, item, index }) => {
+      console.log(
+        `Rendering section: ${section.title}, collapsed: ${collapsedSections.has(section.title)}, isFetching: ${isFetching}`,
+      );
       if (!isFetching && !collapsedSections.has(section.title)) {
         const tasks = getTaskListTasks(item, tasksEntities);
 

--- a/src/navigation/dispatch/components/SectionHeader.tsx
+++ b/src/navigation/dispatch/components/SectionHeader.tsx
@@ -1,12 +1,16 @@
-import { useTranslation } from "react-i18next";
-import { Icon, ChevronUpIcon, ChevronDownIcon } from '@/components/ui/icon';
+import { useTranslation } from 'react-i18next';
 import { Text } from '@/components/ui/text';
-import { TouchableOpacity, View } from "react-native";
+import { TouchableOpacity, View } from 'react-native';
 
-import { useBackgroundHighlightColor } from "../../../styles/theme";
-import { darkGreyColor, whiteColor } from "../../../styles/common";
+import { useBackgroundHighlightColor } from '../../../styles/theme';
+import { darkGreyColor, whiteColor } from '../../../styles/common';
+import FAIcon from '@/src/components/Icon';
 
-export function SectionHeader({ section, collapsedSections, setCollapsedSections }) {
+export function SectionHeader({
+  section,
+  collapsedSections,
+  setCollapsedSections,
+}) {
   const { t } = useTranslation();
 
   const bgHighlightColor = useBackgroundHighlightColor();
@@ -64,9 +68,14 @@ export function SectionHeader({ section, collapsedSections, setCollapsedSections
           </Text>
         </View>
         {section.tasksCount === 0 ? null : (
-          <Icon
-            as={collapsedSections.has(section.title) ? ChevronDownIcon : ChevronUpIcon}
+          <FAIcon
+            name={
+              collapsedSections.has(section.title)
+                ? 'chevron-down'
+                : 'chevron-up'
+            }
             testID={`${section.id}:toggler`}
+            color={darkGreyColor}
           />
         )}
       </TouchableOpacity>

--- a/src/navigation/order/components/OrderAccordeon.tsx
+++ b/src/navigation/order/components/OrderAccordeon.tsx
@@ -111,7 +111,7 @@ interface OrderAccordeonProps {
 
 function OrderAccordeon({ task }: OrderAccordeonProps) {
   const { t } = useTranslation();
-  const taskTitle = getTaskTitleForOrder(task, t);
+  const taskTitle = getTaskTitleForOrder(task);
   const timeframe = getTimeFrame(task);
   const address = task.address.streetAddress;
   const packageType = getPackagesSummary(task);
@@ -163,7 +163,7 @@ function OrderAccordeon({ task }: OrderAccordeonProps) {
                           color: headerText,
                           marginLeft: 12,
                         }}>
-                        {taskTitle}
+                        {taskTitle || (task.type === 'PICKUP' ? t('PICKUP') : t('DROPOFF'))}
                       </AccordionTitleText>
                     </HStack>
                     <HStack space="md" style={{ alignItems: 'center' }}>

--- a/src/navigation/order/utils.ts
+++ b/src/navigation/order/utils.ts
@@ -99,18 +99,17 @@ export const getUniqueTagsFromTasks = (tasks: Tasks) => {
   return uniqueTags;
 };
 
-export function getTaskTitleForOrder(task: Task, t: TFunction): string {
-  const getFallbackTitle = () =>
-    task.type === 'PICKUP' ? t('PICKUP') : t('DROPOFF');
-
+export function getTaskTitleForOrder(task: Task): string {
   const addressData = [];
+
   if (task.address.name) {
     addressData.push(task.address.name);
   }
   if (task.address.contactName) {
     addressData.push(task.address.contactName);
   }
-  return addressData.length > 0 ? addressData.join(' - ') : getFallbackTitle();
+
+  return addressData.join(' - ');
 }
 
 export function formatDistance(

--- a/src/navigation/task/components/Details.tsx
+++ b/src/navigation/task/components/Details.tsx
@@ -2,7 +2,7 @@ import { Button, ButtonText } from '@/components/ui/button';
 import { HStack } from '@/components/ui/hstack';
 import { Icon, ArrowRightIcon } from '@/components/ui/icon';
 import { Text } from '@/components/ui/text';
-import { FlatList, TouchableOpacity, View } from 'react-native';
+import { FlatList, StyleSheet, TouchableOpacity, View } from 'react-native';
 import React from 'react';
 import { withTranslation } from 'react-i18next';
 import { phonecall } from 'react-native-communications';
@@ -17,8 +17,18 @@ import {
 } from '../../../components/PaymentMethodInfo';
 import { formatPrice } from '../../../utils/formatting';
 import { getAddress, getName, getPackagesSummary, getTimeFrame } from './utils';
-import { getTaskTitle } from '../../../shared/src/utils';
 import Detail from '../../../components/Detail';
+
+export const styles = StyleSheet.create({
+  titleText: {
+    fontWeight: 'bold',
+    fontSize: 16,
+    paddingLeft: 10,
+    marginVertical: 10,
+  },
+  // This one is used just for dev and e2e tests purposes
+  invisibleText: __DEV__ ? { fontSize: 12 } : { color: 'transparent', fontSize: 0 },
+});
 
 const Details = ({ task, onTaskTitleClick, t }) => {
   const timeframe = getTimeFrame(task);
@@ -27,14 +37,9 @@ const Details = ({ task, onTaskTitleClick, t }) => {
   address = name ? [name, address].join(' - ') : address;
 
   const renderTaskTitle = () => (
-    <Text
-      style={{
-        fontWeight: 'bold',
-        fontSize: 16,
-        paddingLeft: 10,
-        marginVertical: 10,
-      }}>
-      {getTaskTitle(task)}
+    <Text style={styles.titleText}>
+      {task.orgName}
+      <Text style={styles.invisibleText}>{` (task #${task.id})`}</Text>
     </Text>
   );
 

--- a/src/shared/src/logistics/redux/__tests__/taskUtils.test.js
+++ b/src/shared/src/logistics/redux/__tests__/taskUtils.test.js
@@ -612,12 +612,12 @@ describe('taskUtils', () => {
         { id: 1, type: 'PICKUP', metadata: { order_number: 'ORD-001', order_total: 100 } },
         { id: 2, type: 'PICKUP', metadata: { order_number: 'ORD-001', order_total: 100 } },
         { id: 3, type: 'DROPOFF', metadata: { order_number: 'ORD-001', order_total: 100 } },
-        
+
         // Order 2 - multiple DROPOFFs
         { id: 4, type: 'PICKUP', metadata: { order_number: 'ORD-002', order_total: 200 } },
         { id: 5, type: 'DROPOFF', metadata: { order_number: 'ORD-002', order_total: 200 } },
         { id: 6, type: 'DROPOFF', metadata: { order_number: 'ORD-002', order_total: 200 } },
-        
+
         // Order 3 - no multiple tasks
         { id: 7, type: 'PICKUP', metadata: { order_number: 'ORD-003', order_total: 300 } },
         { id: 8, type: 'DROPOFF', metadata: { order_number: 'ORD-003', order_total: 300 } },
@@ -630,12 +630,12 @@ describe('taskUtils', () => {
         { id: 1, type: 'PICKUP', metadata: { order_number: 'ORD-001', order_total: null } },
         { id: 2, type: 'PICKUP', metadata: { order_number: 'ORD-001', order_total: null } },
         { id: 3, type: 'DROPOFF', metadata: { order_number: 'ORD-001', order_total: 100 } },
-        
+
         // Order 2 - first PICKUP keeps order_total
         { id: 4, type: 'PICKUP', metadata: { order_number: 'ORD-002', order_total: 200 } },
         { id: 5, type: 'DROPOFF', metadata: { order_number: 'ORD-002', order_total: null } },
         { id: 6, type: 'DROPOFF', metadata: { order_number: 'ORD-002', order_total: null } },
-        
+
         // Order 3 - unchanged
         { id: 7, type: 'PICKUP', metadata: { order_number: 'ORD-003', order_total: null } },
         { id: 8, type: 'DROPOFF', metadata: { order_number: 'ORD-003', order_total: 300 } },

--- a/src/shared/src/logistics/redux/taskUtils.ts
+++ b/src/shared/src/logistics/redux/taskUtils.ts
@@ -162,7 +162,7 @@ export function filterTasksByKeyword(tasks, keyword: string) {
 
 export function taskIncludesKeyword(task, keyword: string): boolean {
   return (
-    standardIncludes(task.id, keyword) ||
+    standardIncludes(`#${task.id}`, keyword) ||
     standardIncludes(task.assignedTo, keyword) ||
     standardIncludes(task.orgName, keyword) ||
     standardIncludes(task.metadata?.order_number, keyword) ||

--- a/src/shared/src/logistics/redux/taskUtils.ts
+++ b/src/shared/src/logistics/redux/taskUtils.ts
@@ -3,7 +3,6 @@ import ColorHash from 'color-hash';
 import moment from 'moment';
 
 import { getUserTaskList } from './taskListUtils';
-import { getTaskTitle } from '../../utils';
 // WHEN TASK IS ADDED, uncomment the following line
 // import { Task } from '../../../../types/Task';
 
@@ -154,37 +153,28 @@ export function getToursToUpdate(itemIds, toursTasksIndex) {
 }
 
 export function filterTasksByKeyword(tasks, keyword: string) {
-  if (keyword === '') {
+  if (!(keyword && keyword.length > 0)) {
     return tasks;
   }
 
-  return tasks.filter(
-    task =>
-      taskIncludesKeyword(task, keyword) ||
-      taskIncludesKeywordInOrder(task, keyword),
-  );
+  return tasks.filter(task => taskIncludesKeyword(task, keyword));
 }
 
-export function taskIncludesKeyword(task, keyword: string) {
+export function taskIncludesKeyword(task, keyword: string): boolean {
   return (
+    standardIncludes(task.id, keyword) ||
     standardIncludes(task.assignedTo, keyword) ||
     standardIncludes(task.orgName, keyword) ||
-    standardIncludes(getTaskTitle(task), keyword) ||
-    task.tags.reduce(
-      (acc, tag) => acc || standardIncludes(tag.name, keyword),
-      false,
-    )
-  );
-}
-
-export function taskIncludesKeywordInOrder(task, keyword: string) {
-  return (
     standardIncludes(task.metadata?.order_number, keyword) ||
+    standardIncludes(task.address?.name, keyword) ||
     standardIncludes(task.address?.contactName, keyword) ||
     standardIncludes(task.address?.firstName, keyword) ||
     standardIncludes(task.address?.lastName, keyword) ||
-    standardIncludes(task.address?.name, keyword) ||
-    standardIncludes(task.address?.streetAddress, keyword)
+    standardIncludes(task.address?.streetAddress, keyword) ||
+    task.tags.reduce(
+      (acc, tag) => acc || standardIncludes(tag.name, keyword),
+      false
+    )
   );
 }
 
@@ -193,10 +183,9 @@ function standardIncludes(originalString: string, keyword: string) {
     return false;
   }
 
-  const lowercaseKeyword = keyword.toLowerCase();
-
-  return originalString.toLowerCase().includes(lowercaseKeyword);
+  return originalString.toLowerCase().includes(keyword.toLowerCase());
 }
+
 export function taskExists(list, task) {
   return list.some(t => t['@id'] === task['@id']);
 }

--- a/src/shared/src/utils.js
+++ b/src/shared/src/utils.js
@@ -13,14 +13,6 @@ export function isSameDayTour(tour, date) {
   return moment(tour.date).isSame(date, 'day');
 }
 
-export function getTaskTitle(task) {
-  return task.orgName
-    ? task.metadata?.order_number
-      ? task.orgName
-      : `${task.orgName} - ${i18n.t('TASK_WITH_ID', { id: task.id })}`
-    : i18n.t('TASK_WITH_ID', { id: task.id });
-}
-
 export function getDropoffPosition(task, tasks) {
   const pickupOrderTasks = tasks.filter(t => t.type === 'PICKUP');
   const dropoffOrderTasks = tasks.filter(t => t.type === 'DROPOFF');


### PR DESCRIPTION
## Issue https://github.com/coopcycle/coopcycle/issues/507

### Related issues:
* https://github.com/coopcycle/coopcycle/issues/324 with PR https://github.com/coopcycle/coopcycle-app/pull/2029
* https://github.com/coopcycle/coopcycle/issues/459 with PR https://github.com/coopcycle/coopcycle-app/pull/2036
We'll probably have some of this issue's tasks aready done from these above.
* https://github.com/coopcycle/coopcycle/issues/508

### Tasks:
- [x] Adjust icons size (the ones we display when we swipe left/right) and check that all icons have the right size (ie, the "task started" status, bulk assign button, etc).
- [x] Adjust alignment for icons, texts and any other thing that are now not correctly aligned as they were before.
- [x] Long-tap a `TaskListItem` makes the background black, let's change to another less "agressive" color (like gray? ask Lua).
- [x] Evaluate if it worths to update the current section/tasklist accordeon with the gluestack one.
  - We'll finally stick to the original/old accordeon. We'll only use gluestack's styles.
- [x] Adjust the right vertical status bar position that is now missplaced.
- [x] Remove this crazy green icon/button that somehow appeared on the right:
<img width="300" alt="Image" src="https://github.com/user-attachments/assets/2f65bb6c-828d-4e43-8351-18881bc72955" />

It seems to be the icon for the bulk mark-as-done/started from courier section.
See `src/components/TaskList.tsx` from [this commit](https://github.com/coopcycle/coopcycle-app/pull/2037/commits/4f3fd7ec08667622d8d24620a76e6cbd4ebf7704) from PR https://github.com/coopcycle/coopcycle-app/pull/2037
The change: That button is now only parsed at courier section (using courier context).

- [x] Adjust the timeslots style for dark-mode.
- [x] Make all the sections collapsed on dispatch screen on 1st load.
- [x] Make the map markers to be better viewed in dark-mode at courier section (seems that is better at dispatch section)
  - [x] Add the "warning dot" in the marker with the same logic as `TasksMapView._getWarnings(task)`.

<img width="290" height="230" alt="image" src="https://github.com/user-attachments/assets/b262dd9f-a299-4a2f-b0dc-bfdab91831bb" />

  - [x] Make the unassigned polylines brighter.
  - [x] See this issue and mark it as done: https://github.com/coopcycle/coopcycle/issues/518
  - [x] Test if the markers icons are not appearing when 1st loading the map from courier section.
  It's some kind of a data loading issue (they sometimes blink randomly).

https://github.com/user-attachments/assets/58cd66b7-8dc5-4f92-a0f3-69b0c0155f94


- [x] Make sure that everything looks good also in the courier section/screen.
- [x] Make sure it looks good also in dark-mode (both sections).
- [x] Make sure all tests pass!