### PR TITLE
[PERTE-526] Fetching possibly missing tasks data on order detail screen

### DIFF
--- a/src/components/NotificationHandler.tsx
+++ b/src/components/NotificationHandler.tsx
@@ -3,7 +3,6 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import {
   clearNotifications,
-  shouldNotificationBeDisplayed,
   startSound,
   stopSound,
 } from '../redux/App/actions';

--- a/src/components/TaskInfo.tsx
+++ b/src/components/TaskInfo.tsx
@@ -2,7 +2,6 @@ import { HStack } from '@/components/ui/hstack';
 import { Icon } from '@/components/ui/icon';
 import { Text } from '@/components/ui/text';
 import { VStack } from '@/components/ui/vstack';
-import moment from 'moment';
 import React, { useEffect, useRef } from 'react';
 import { Animated, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
@@ -22,6 +21,7 @@ import { selectFilteredTasksByOrder as selectTasksByOrderCourier } from '../redu
 import { selectTasksByOrder as selectTasksByOrderLogistics } from '../redux/logistics/selectors';
 import { getOrderNumber } from '../utils/tasks';
 import { getTaskTitleForOrder } from '../navigation/order/utils';
+import { getTimeFrame } from '../navigation/task/components/utils';
 import { useTaskListsContext } from '../navigation/courier/contexts/TaskListsContext';
 
 const cardBorderRadius = 2.5;
@@ -173,7 +173,7 @@ function TaskInfo({ task, isPickup, taskTestId }: ITaskInfoProps) {
           className="items-center"
           style={isPickup ? { justifyContent: 'flex-end' } : undefined}>
           <Text className="pr-2" style={alignedTextStyle}>
-            {`${moment(task.doneAfter).format('LT')} - ${moment(task.doneBefore).format('LT')}`}
+            {getTimeFrame(task)}
           </Text>
           {/* TODO confirm -- why this? shouldn't this be comments? */}
           {task.comments ? <FAIcon name="comments" /> : null}

--- a/src/navigation/dispatch/useAllTasks.ts
+++ b/src/navigation/dispatch/useAllTasks.ts
@@ -33,7 +33,10 @@ export function useAllTasks(date: moment.Moment) {
     isError: isErrorCourierUsers,
     isLoading: isLoadingCourierUsers,
     isFetching: isFetchingCourierUsers,
-  } = useGetCourierUsersQuery();
+  } = useGetCourierUsersQuery(undefined, {
+      refetchOnFocus: true,
+      // @TODO SEE IF WE CAN GIVE A CACHE TTL...!
+    });
 
   const {
     data: taskLists,
@@ -41,7 +44,10 @@ export function useAllTasks(date: moment.Moment) {
     isFetching: isFetchingTaskLists,
     isLoading: isLoadingTaskLists,
     refetch: refetchTaskLists,
-  } = useGetTaskListsV2Query(dateOnlyString);
+  } = useGetTaskListsV2Query(dateOnlyString, {
+      refetchOnFocus: true,
+      // @TODO SEE IF WE CAN GIVE A CACHE TTL...!
+    });
 
   const {
     data: tasks,
@@ -49,7 +55,10 @@ export function useAllTasks(date: moment.Moment) {
     isFetching: isFetchingTasks,
     isLoading: isLoadingTasks,
     refetch: refetchTasks,
-  } = useGetTasksQuery(dateOnlyString);
+  } = useGetTasksQuery(dateOnlyString, {
+      refetchOnFocus: true,
+      // @TODO SEE IF WE CAN GIVE A CACHE TTL...!
+    });
 
   const {
     data: tours,
@@ -57,7 +66,10 @@ export function useAllTasks(date: moment.Moment) {
     isFetching: isFetchingTours,
     isLoading: isLoadingTours,
     refetch: refetchTours,
-  } = useGetToursQuery(dateOnlyString);
+  } = useGetToursQuery(dateOnlyString, {
+      refetchOnFocus: true,
+      // @TODO SEE IF WE CAN GIVE A CACHE TTL...!
+    });
 
   const isError = useMemo(() => {
     return (

--- a/src/navigation/order/Order.tsx
+++ b/src/navigation/order/Order.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useState } from 'react';
-import { ActivityIndicator, FlatList, View } from 'react-native';
+import React, { useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, FlatList, LayoutChangeEvent, View } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import { selectFilteredTasksByOrder as selectTasksByOrderCourier } from '../../redux/Courier/taskSelectors';
@@ -14,39 +14,46 @@ import OrderAccordeon from './components/OrderAccordeon';
 import OrderDetail from './components/OrderDetail';
 import { RouteType } from './types';
 import { Box } from '@/components/ui/box';
-import { useGetTaskContextQuery } from '@/src/redux/api/slice';
+import { apiSlice, useGetTaskContextQuery } from '@/src/redux/api/slice';
 
-const Order = ({ route }: { route: RouteType }) => {
+const Order = ({ route }: RouteType) => {
   const [mapDimensions, setMapDimensions] = useState({ height: 0, width: 0 });
   const aspectRatio = useMemo(
     () => getAspectRatio(mapDimensions),
     [mapDimensions],
   );
-  const { orderNumber, isFromCourier } = route.params;
+  const { orderNumber, isFromCourier, orderDate, taskIds } = route.params;
   const selectSelector = isFromCourier
     ? selectTasksByOrderCourier
     : selectTasksByOrderLogistics;
-  const orderTasks = useSelector(selectSelector(orderNumber));
+  const orderTasksFromState = useSelector(selectSelector(orderNumber));
+  const [trigger, { data, isLoading, isFetching }] = apiSlice.endpoints.getTasks.useLazyQuery();
 
-  // Ugly workaround for colors for courier
-  const tasks = useMemo(() => {
-    if (isFromCourier) {
-      const taskList = createCurrentTaskList(orderTasks);
-      // Override color for courier
-      return taskList.items.map(task => ({ ...task, color: blueColor }));
+  // Get missing tasks data when fetched if needed
+  const orderTasks = useMemo(() => {
+    if (!data?.length) return orderTasksFromState;
+
+    return data.filter(task => taskIds?.includes(task.id));
+  }, [orderTasksFromState, data, taskIds]);
+
+  // Fetch missing tasks if needed
+  useEffect(() => {
+    if (orderTasks.length === 0 && orderDate && taskIds?.length && !isFetching) {
+      console.log(`Fetching missing tasks data for '${orderDate}':`, taskIds);
+      trigger(orderDate);
     }
-    return orderTasks;
-  }, [orderTasks, isFromCourier]);
+  }, [orderTasks, orderDate, taskIds, isFetching, trigger]);
 
-  const firstTaskId = tasks.length ? tasks[0].id : null;
-  const {data, isLoading, isFetching} = useGetTaskContextQuery(firstTaskId, {skip: !firstTaskId});
+  const firstTaskId = orderTasks?.length ? orderTasks[0].id : null;
+  const { data: taskCtxData, isLoading: taskCtxLoading, isFetching: taskCtxFetching } = useGetTaskContextQuery(firstTaskId, {skip: !firstTaskId});
 
+  // Fetch context to get order distance/duration/polyline
   const tasksWithContext = useMemo(() => {
-    if(!data?.delivery) return tasks;
+    if(!taskCtxData?.delivery) return orderTasks;
 
-    const { distance, duration, polyline } = data.delivery;
+    const { distance, duration, polyline } = taskCtxData.delivery;
 
-    return tasks.map(task => ({
+    return orderTasks.map(task => ({
       ...task,
       metadata: {
         ...task.metadata,
@@ -55,14 +62,24 @@ const Order = ({ route }: { route: RouteType }) => {
         polyline
       }
     }))
-  }, [tasks, data]);
+  }, [orderTasks, taskCtxData]);
 
-  const handleLayout = e => {
+  // Ugly workaround for colors for courier
+  const tasks = useMemo(() => {
+    if (isFromCourier) {
+      const taskList = createCurrentTaskList(tasksWithContext);
+      // Override color for courier
+      return taskList.items.map(task => ({ ...task, color: blueColor }));
+    }
+    return tasksWithContext;
+  }, [tasksWithContext, isFromCourier]);
+
+  const handleLayout = (e: LayoutChangeEvent) => {
     const { width, height } = e.nativeEvent.layout;
     setMapDimensions({ height, width });
   };
 
-  if (isLoading || isFetching) {
+  if (isLoading || taskCtxLoading || isFetching || taskCtxFetching) {
     return (
       <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
         <ActivityIndicator animating={true} size="large" />
@@ -74,21 +91,21 @@ const Order = ({ route }: { route: RouteType }) => {
     <View>
       <View style={{ height: '35%' }} onLayout={handleLayout}>
         <TaskMiniMap
-          tasks={tasksWithContext}
+          tasks={tasks}
           aspectRatio={aspectRatio}
           onLayout={handleLayout}
         />
       </View>
       <FlatList
         style={{ height: '65%' }}
-        data={tasksWithContext}
+        data={tasks}
         keyExtractor={(item, index) => `${item.id}-${index}`}
         renderItem={({ item }) => (
           <Box style={{ paddingHorizontal: 12 }}>
             <OrderAccordeon task={item as Task} />
           </Box>
         )}
-        ListHeaderComponent={<OrderDetail tasks={tasksWithContext} />}
+        ListHeaderComponent={<OrderDetail tasks={tasks} />}
       />
     </View>
   );

--- a/src/navigation/order/components/OrderAccordeon.tsx
+++ b/src/navigation/order/components/OrderAccordeon.tsx
@@ -22,7 +22,7 @@ import TaskTagsList from '../../../components/TaskTagsList';
 import TaskTypeIcon from '../../../components/TaskTypeIcon';
 import { useBaseTextColor } from '../../../styles/theme';
 import { Task, TaskTag } from '../../../types/task';
-import { getPackagesSummary, getTimeFrame } from '../../task/components/utils';
+import { addDayIfNotToday, getPackagesSummary, getTimeFrame } from '../../task/components/utils';
 import { getTaskTitleForOrder } from '../utils';
 
 interface PackageSummary {
@@ -105,6 +105,7 @@ const ContentText = ({
     </Box>
   );
 };
+
 interface OrderAccordeonProps {
   task: Task;
 }
@@ -112,7 +113,6 @@ interface OrderAccordeonProps {
 function OrderAccordeon({ task }: OrderAccordeonProps) {
   const { t } = useTranslation();
   const taskTitle = getTaskTitleForOrder(task);
-  const timeframe = getTimeFrame(task);
   const address = task.address.streetAddress;
   const packageType = getPackagesSummary(task);
   const comments = task.comments;
@@ -168,7 +168,7 @@ function OrderAccordeon({ task }: OrderAccordeonProps) {
                     </HStack>
                     <HStack space="md" style={{ alignItems: 'center' }}>
                       <Text bold style={{ color: headerText }}>
-                        {timeframe}
+                        {getTaskTimeFrame(task, "\n")}
                       </Text>
                       <Divider orientation="vertical" className="h-8" />
                       <Text bold style={{ color: headerText, flexShrink: 1 }}>
@@ -192,7 +192,7 @@ function OrderAccordeon({ task }: OrderAccordeonProps) {
           </Box>
 
           <ContentText
-            timeframe={timeframe}
+            timeframe={getTaskTimeFrame(task, " ")}
             packageType={packageType}
             tags={task.tags}
             streetAddress={address}
@@ -205,6 +205,13 @@ function OrderAccordeon({ task }: OrderAccordeonProps) {
         </AccordionContent>
       </AccordionItem>
     </Accordion>
+  );
+}
+
+function getTaskTimeFrame(task: Task, separator: string) {
+  return (
+    addDayIfNotToday(task.doneAfter, separator) +
+    getTimeFrame(task)
   );
 }
 

--- a/src/navigation/order/types.ts
+++ b/src/navigation/order/types.ts
@@ -1,3 +1,12 @@
+import { DateOnlyString } from '../../utils/date-types';
+
 export interface RouteType {
-  route: { params: { orderNumber: string | number; isFromCourier: boolean } };
+  route: {
+    params: {
+      orderNumber: string | number;
+      isFromCourier: boolean;
+      orderDate?: DateOnlyString;
+      taskIds?: Array<number>;
+    }
+  };
 }

--- a/src/navigation/task/components/utils.ts
+++ b/src/navigation/task/components/utils.ts
@@ -1,18 +1,27 @@
 import moment from 'moment';
 
+export const addDayIfNotToday = (date, separator=' ') => {
+  return moment(date).format('YYYYMMDD') === moment().format('YYYYMMDD') ? '' : `(${moment(date).format('MMM Do')})${separator}`;
+}
+
+export const formatTime = (date) => {
+  return moment(date).format('HH:mm');
+}
+
 export const getOrderTimeFrame = tasks => {
   return (
-    moment(tasks[0].doneAfter).format('LT') +
+    addDayIfNotToday(tasks[0].doneAfter) +
+    formatTime(tasks[0].doneAfter) +
     ' - ' +
-    moment(tasks[tasks.length - 1].doneBefore).format('LT')
+    formatTime(tasks[tasks.length - 1].doneBefore)
   );
 };
 
 export const getTimeFrame = task => {
   return (
-    moment(task.doneAfter).format('LT') +
+    formatTime(task.doneAfter) +
     ' - ' +
-    moment(task.doneBefore).format('LT')
+    formatTime(task.doneBefore)
   );
 };
 

--- a/src/navigation/utils.ts
+++ b/src/navigation/utils.ts
@@ -1,9 +1,10 @@
 let navigateAfter = null;
 
-export const navigateToOrder = (navigation, orderNumber, isFromCourier = false) => {
+export const navigateToOrder = (navigation, orderNumber: string, isFromCourier = false, extraData = {}) => {
   const params = {
     orderNumber,
     isFromCourier,
+    ...extraData
   };
   navigation.navigate('Order', { screen: 'Order', params });
 };

--- a/src/redux/middlewares/PushNotificationMiddleware/index.ts
+++ b/src/redux/middlewares/PushNotificationMiddleware/index.ts
@@ -58,10 +58,14 @@ export default ({ getState, dispatch }) => {
 
     if (event && event.name === EVENT_DELIVERY.CREATED) {
       const orderNumber = message.data.order_number;
+      const extraData = {
+        orderDate: message.data.date,
+        taskIds: message.data.task_ids || []
+      };
       // Here in any case, we navigate to the delivery/order that was tapped,
       // it should have been loaded via WebSocket already.
       // (and we always assume to be admin/dispatcher, so isFromCourier = false)
-      navigateToOrder(navigationRef.current, orderNumber, false);
+      navigateToOrder(navigationRef.current, orderNumber, false, extraData);
     }
 
     if (event && event.name === EVENT_TASK_COLLECTION.CHANGED) {


### PR DESCRIPTION
## Issue https://github.com/coopcycle/coopcycle/issues/526

### Related PR:
- https://github.com/coopcycle/coopcycle-web/pull/5106

Fetching possibly missing tasks data when opening the order detail screen.
This could happen for example, when tapping a push notification for a new delivery in a future date (or any date that is not today and/or the currently selected date in the dispatch screen).
We only have in the state the tasks for the currently selected date.
That's why we have to fetch tasks for any other date.

### :warning:  Important:
We've introduced the use of RTK's `refetchOnFocus: true` at hook `src/navigation/dispatch/useAllTasks.ts` to all queries done in there.
(see commit: https://github.com/coopcycle/coopcycle-app/pull/2054/commits/2aa44fea279d683193b01311ce58b56bc3da7971#diff-4328e86e7e974d9fe013a7b2652a032d91f9975d59c1f93b04d263a8d19f0405)
**This will cause to also fetch all that data again when the user returns to the app.**
As a TODO note for the future: See if we can give a cache TTL or some tweak parameters.

### Tasks:
- [x] The `admin/dispatcher` role should have precedence over the `courier` one, so we need to call the endpoint that saves the tasks into the `logistics` redux state key.
- [x] Tapping the push notification should display the order detail screen with its tasks data populated, no matter the order date.
- [x] In the meantime, display 'HH:mm' time format for tasks in all places.
  - [x] If today is not the task's date, then display the date with the format '(MMM Do)' before the time.
- [x] Make sure it keeps working fine for just a courier role user.
- [ ] Make sure all tests pass!