### PR TITLE
[PERTE-531] Time status vertical bars

### DIFF
--- a/src/components/TaskPriorityStatus.tsx
+++ b/src/components/TaskPriorityStatus.tsx
@@ -11,6 +11,9 @@ export const TaskPriorityStatus = ({
   task: Task;
   cardBorderRadius: number;
 }) => {
+  if (task.status === 'DONE' || task.status === 'FAILED') {
+    return null;
+  }
   //Ensure future tasks return a positive value and overdue tasks return a negative one.
   const timeDifference = moment(task.doneBefore).diff(moment());
   let backgroundColor = whiteColor;


### PR DESCRIPTION
## Issue https://github.com/coopcycle/coopcycle/issues/531

<img width="437" height="506" alt="Image" src="https://github.com/user-attachments/assets/19e36e0d-a35d-40dd-8817-b7c856017dc8" />

### Tasks:
- [x] Make sure the times hardcoded in the app are respected (`TaskPriorityStatus`).
Take into account the current day!
```
if (timeDifference < minutes(10)) {
    backgroundColor = '#FFC300';
  } else if (timeDifference < minutes(0)) {
    backgroundColor = '#B42205';
  } else {
    return null;
  }
```
- [x] Take into account the task status: only display the bars if the task is NOT in a "final" state/status (ie "DONE"/"FAILED").
  - If the user is viewing tasks from a past day, they the vertical bar should only appear in those tasks that weren't done (still pending).
- [x] Make sure it looks good on dark-mode.
- [x] Make sure it works fine at iOS (using the remote mac).
- [x] Make sure all tests pass!