### PR TITLE
[PERTE-495] Put back the number of packages in tasklists

### DIFF
--- a/src/components/TaskInfo.tsx
+++ b/src/components/TaskInfo.tsx
@@ -41,6 +41,19 @@ export const styles = StyleSheet.create({
   hasIncident: {
     borderColor: yellowColor,
   },
+  packageText: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'flex-end',
+    alignSelf: 'flex-end',
+  },
+  row: {
+    flexWrap: 'wrap',
+  },
+  rowRight: {
+    flexWrap: 'wrap',
+    justifyContent: 'flex-end',
+  },
 });
 
 interface DropoffArrowsProps {
@@ -87,6 +100,10 @@ function TaskInfo({ task, isPickup, taskTestId }: ITaskInfoProps) {
     { flex: 1, marginRight: 8 },
     ...(isPickup ? [{ textAlign: 'right' as const }] : []),
   ];
+
+  const packagesText = task.packages?.length
+    ? task.packages.map(p => `${p.quantity} x ${p.short_code}`).join('   ')
+    : '';
 
   // TODO check if we should replace by SVG icons (css rotation not working on load)
   const pickupRotation = useRef(new Animated.Value(0)).current;
@@ -169,14 +186,32 @@ function TaskInfo({ task, isPickup, taskTestId }: ITaskInfoProps) {
         <Text numberOfLines={1} style={alignedTextStyle}>
           {task.address.streetAddress}
         </Text>
-        <HStack
-          className="items-center"
-          style={isPickup ? { justifyContent: 'flex-end' } : undefined}>
-          <Text className="pr-2" style={alignedTextStyle}>
-            {getTimeFrame(task)}
-          </Text>
-          {/* TODO confirm -- why this? shouldn't this be comments? */}
-          {task.comments ? <FAIcon name="comments" /> : null}
+        <HStack className="items-center" style={isPickup ? styles.rowRight : styles.row}>
+          {isPickup ? (
+            <>
+              {packagesText && (
+                <View style={styles.packageText}>
+                  <Text style={{ textAlign: 'right' }}>
+                    {packagesText} |
+                  </Text>
+                </View>
+              )}
+              <Text style={{ textAlign: 'right' }}> {getTimeFrame(task)} </Text>
+              {task.comments && <FAIcon name="comments" />}
+            </>
+          ) : (
+            <>
+              <Text>{getTimeFrame(task)} </Text>
+              {packagesText && (
+                <View style={styles.packageText}>
+                  <Text>
+                    | {packagesText}
+                  </Text>
+                </View>
+              )}
+              {task.comments && <FAIcon name="comments" />}
+            </>
+          )}
         </HStack>
         {task.tags && task.tags.length ? (
           <View style={isPickup ? { alignSelf: 'flex-end' } : undefined}>

--- a/src/navigation/dispatch/TasksFilters.tsx
+++ b/src/navigation/dispatch/TasksFilters.tsx
@@ -144,7 +144,7 @@ function SettingsItemInner({ item }) {
 
 function SettingsItemSwitch({ item }) {
   return (
-    <HStack className="items-center justify-between py-3">
+    <HStack className="items-center justify-between py-3 mr-5">
       <Text>{item.label}</Text>
       <Switch
         onToggle={item.onToggle}


### PR DESCRIPTION
## Issue https://github.com/coopcycle/coopcycle/issues/495

Put back the number of packages in tasklists for both courier and dispatcher.

### Tasks:
- [x] Display package quantities and short names
- [x] Make sure it works fine at iOS (using the remote mac).
- [x] Make sure all test pass!