### PR TITLE
[PERTE-577] Unable to enter a custom pickup address

### DIFF
--- a/src/navigation/delivery/NewDeliveryPickupAddress.tsx
+++ b/src/navigation/delivery/NewDeliveryPickupAddress.tsx
@@ -206,7 +206,8 @@ function NewDeliveryPickupAddress({ navigation }) {
           </View>
           <View style={[styles.formGroup, { zIndex: 2 }]}>
             <Checkbox
-              value={customAddress}
+              value="customAddress"
+              isChecked={customAddress}
               onChange={() => setCustomAddress(!customAddress)}>
               <CheckboxIndicator>
                 <CheckboxIcon as={CheckIcon} />


### PR DESCRIPTION
## Issue https://github.com/coopcycle/coopcycle/issues/577

The app crashes when tapping "Use custom pickup address" on new delivery form.

See https://coopcycle.slack.com/archives/C08C64Z8E4Q/p1762857691473099

### Tasks:
- [x] Fix the problem.
- [x] Make sure it works fine at iOS (using the remote mac).
- [x] Make sure all tests pass!