### PR TITLE
fix: All tasks dissapear from app's dispatch section on refresh auth token

### DIFF
--- a/src/redux/logistics/taskEntityReducers.ts
+++ b/src/redux/logistics/taskEntityReducers.ts
@@ -1,6 +1,6 @@
 import { actionMatchCreator } from '../util';
 import { changeDate, loadTasksSuccess } from '../Dispatch/actions';
-import { SET_USER } from '../App/actions';
+import { LOGOUT_SUCCESS } from '../App/actions';
 import {
   assignTaskSuccess,
   assignTasksSuccess,
@@ -23,7 +23,7 @@ import {
 const initialState = taskAdapter.getInitialState();
 
 export default (state = initialState, action) => {
-  if (changeDate.match(action) || action.type === SET_USER) {
+  if (changeDate.match(action) || action.type === LOGOUT_SUCCESS) {
     return initialState;
   }
 

--- a/src/redux/logistics/taskListEntityReducers.ts
+++ b/src/redux/logistics/taskListEntityReducers.ts
@@ -4,12 +4,12 @@ import {
   taskListUtils,
   updateTaskListsSuccess,
 } from '../../coopcycle-frontend-js/logistics/redux';
-import { SET_USER } from '../App/actions';
+import { LOGOUT_SUCCESS } from '../App/actions';
 
 const initialState = taskListAdapter.getInitialState();
 
 export default (state = initialState, action) => {
-  if (changeDate.match(action) || action.type === SET_USER) {
+  if (changeDate.match(action) || action.type === LOGOUT_SUCCESS) {
     return initialState;
   }
 

--- a/src/redux/logistics/tourEntityReducers.ts
+++ b/src/redux/logistics/tourEntityReducers.ts
@@ -7,12 +7,12 @@ import {
   updateTourSuccess,
 } from '../../shared/logistics/redux';
 import { actionMatchCreator } from '../util';
-import { SET_USER } from '../App/actions';
+import { LOGOUT_SUCCESS } from '../App/actions';
 
 const initialState = tourAdapter.getInitialState();
 
 export default (state = initialState, action) => {
-  if (changeDate.match(action) || action.type === SET_USER) {
+  if (changeDate.match(action) || action.type === LOGOUT_SUCCESS) {
     return initialState;
   }
 


### PR DESCRIPTION
Currently we clean up tasks; task lists and tours on `SET_USER` action, but this action is also dispatched during token refresh which leads to https://github.com/coopcycle/coopcycle/issues/527 Instead, we should clean up the state on `LOGOUT_SUCCESS` action
